### PR TITLE
Channel モデルのテーブルスキーマを調整する

### DIFF
--- a/db/migrate/20240127123627_create_channels.rb
+++ b/db/migrate/20240127123627_create_channels.rb
@@ -5,7 +5,7 @@ class CreateChannels < ActiveRecord::Migration[7.1]
       t.string :description, limit: 255
       t.string :site_link, null: false, limit: 255
       t.string :feed_link, null: false, limit: 255
-      t.string :image_url, null: false, limit: 255
+      t.string :image_url, limit: 255
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -19,7 +19,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_27_132259) do
     t.string "description", limit: 255
     t.string "site_link", limit: 255, null: false
     t.string "feed_link", limit: 255, null: false
-    t.string "image_url", limit: 255, null: false
+    t.string "image_url", limit: 255
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["feed_link"], name: "index_channels_on_feed_link", unique: true


### PR DESCRIPTION
Rails のお作法に則るなら新規の Migration ファイルを追加するところだけど、まだぼくの手元にしか環境がなくて Rollback も容易なので、過去に遡って定義を編集することにします。