### PR TITLE
新着 Item の保存通知がドバッと発生しないように工夫する

### DIFF
--- a/app/jobs/item_creation_notifier_job.rb
+++ b/app/jobs/item_creation_notifier_job.rb
@@ -4,9 +4,13 @@ class ItemCreationNotifierJob < ApplicationJob
   def perform(item_id)
     item = Item.find(item_id)
 
+    # 同じChannelの直近のItemが3分以内に通知されていたら通知しない
+    prev_notified_at = item.channel.items.where.not(id: item.id).order(id: :desc).first&.created_at
+    return if prev_notified_at && prev_notified_at > 3.minute.ago
+
     Faraday.post(
       ENV["DISCORD_WEBHOOK_URL"], {
-        content: "New item created: #{item.url}"
+        content: "[#{Rails.env}] New item created #{item.url}"
       }.to_json,
       "Content-Type" => "application/json"
     )

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -90,23 +90,20 @@ class Channel < ApplicationRecord
         feed.entries
       end
 
-    items_parameters =
-      entries.map do |entry|
-        p ["Fetching", entry.published, entry.title, entry.url]
-        og = OpenGraph.new(entry.url)
-        {
-          guid: entry.entry_id,
-          title: entry.title,
-          url: entry.url,
-          image_url: og.image,
-          published_at: entry.published,
-        }
-      end
+    entries.sort_by(&:published).each do |entry|
+      p ["Fetching", entry.published, entry.title, entry.url]
 
-    items_parameters.sort_by { |item|
-      item[:published_at]
-    }.each { |parameters|
+      sleep 3
+
+      og = OpenGraph.new(entry.url)
+      parameters = {
+        guid: entry.entry_id,
+        title: entry.title,
+        url: entry.url,
+        image_url: og.image,
+        published_at: entry.published,
+      }
       self.items.find_or_initialize_by(guid: parameters[:guid]).update(parameters)
-    }
+    end
   end
 end


### PR DESCRIPTION
特に新規の Channel を登録したとき、初回のフルスキャンで Item がまとめてたくさん保存されるので、通知が爆発する :bomb:

- 同じ Channel 内の Item であれば、一度通知したあとはクールダウン・タイムを設けてみる
- 「新着 Item の情報を一通り揃えてから一気に保存」としていたが「ひとつの Item の情報を揃えたら保存」と逐次で保存を行うようにする
  - 間に sleep も入れておく