### PR TITLE
Channel 登録時の Item 取得に 10 分間以上かかることがあるとわかったので、判定ロジックを見直す

### DIFF
--- a/app/jobs/item_creation_notifier_job.rb
+++ b/app/jobs/item_creation_notifier_job.rb
@@ -19,7 +19,7 @@ class ItemCreationNotifierJob < ApplicationJob
     channel = item.channel
 
     # Channel作成から一定以上の時間が経過しているものは、新着検知されたItemとみなして通知する
-    return true if item.channel.created_at < 10.minutes.ago
+    return true if item.channel.created_at < 1.hour.ago
 
     # Channel作成時に一括でItemが保存されるときは、最新のItemをひとつだけ通知する
     feed = Feedjira.parse(Faraday.get(channel.feed_url).body)


### PR DESCRIPTION
ポッドキャストのフィードにはしばしば全エピソードの情報が含まれて、数百の Item を処理していると 10 分間以上を要することがある :timer_clock:
