### PR TITLE
Channel/Item の画像がない場合はプレイスホルダを表示する

### DIFF
--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -127,4 +127,8 @@ class Channel < ApplicationRecord
   def favicon_url
     "https://www.google.com/s2/favicons?domain_url=#{URI.parse(site_url).host}"
   end
+
+  def image_url_or_placeholder
+    image_url.presence || "https://placehold.jp/30/cccccc/ffffff/300x300.png?text=#{self.title}"
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -9,4 +9,8 @@ class Item < ApplicationRecord
   validates :published_at, presence: true
 
   after_create_commit { ItemCreationNotifierJob.perform_later(self.id) }
+
+  def image_url_or_placeholder
+    image_url.presence || "https://placehold.jp/30/cccccc/ffffff/270x180.png?text=#{self.title}"
+  end
 end

--- a/app/views/channels/_cards.html.erb
+++ b/app/views/channels/_cards.html.erb
@@ -1,7 +1,7 @@
 <div class="cards">
   <% channels.each do |channel| %>
   <div class="card channel-card">
-    <%= image_tag(channel.image_url, width: "100%", height: "100%") if channel.image_url %>
+    <%= image_tag(channel.image_url_or_placeholder, width: "100%", height: "100%") %>
     <h3 class="card-title">
       <%= image_tag(channel.favicon_url, size: "16x16") %>
       <%= link_to(channel.title, channel) %>

--- a/app/views/items/_cards.html.erb
+++ b/app/views/items/_cards.html.erb
@@ -1,7 +1,7 @@
 <div class="cards">
   <% items.each do |item| %>
   <div class="card item-card">
-    <%= image_tag(item.image_url, width: "100%", height: "100%") if item.image_url %>
+    <%= image_tag(item.image_url_or_placeholder, width: "100%", height: "100%") %>
     <h3 class="card-title"><%= link_to(item.title, item.url) %></h3>
     <% if with_channel %>
       <span class="card-channel">


### PR DESCRIPTION
### 変更の意図

Channel と Item の image_url は nil の場合があります。これによってスタイリングの難易度は上がると思うので、仮に「画像は必ず存在するものとする」としたらスタイリングしやすくなるのか？を検証するための、実験的変更です :test_tube:

@sugiwe さんから見て「こういう方がいいね」となるならそのまま使ってもらって「画像があってもなくてもピシッとやりまっせ」となるなら、この変更はあとから破棄してもらっても大丈夫です :wink:

### メモ

https://placehold.jp/rule.html

> 料金について
> 当Webサイトのサービス利用料は無料です。
>
> 禁止事項
> 当Webサイトに過剰にアクセスすること。
>（サーバーが負荷でハングアップするぐらいでなければ特に問題ありません。）
