### PR TITLE
OpenGraph クラス、リダイレクトを追従して og:image をもっと取れるように

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem "rails", "~> 7.1.3"
 
 gem "bootsnap", require: false
 gem "faraday"
+gem "faraday_middleware"
 gem "feedbag"
 gem "feedjira"
 gem "googleauth"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,10 +103,11 @@ GEM
     drb (2.2.0)
       ruby2_keywords
     erubi (1.12.0)
-    faraday (2.9.0)
-      faraday-net_http (>= 2.0, < 3.2)
-    faraday-net_http (3.1.0)
-      net-http
+    faraday (1.2.0)
+      multipart-post (>= 1.2, < 3)
+      ruby2_keywords
+    faraday_middleware (1.2.0)
+      faraday (~> 1.0)
     feedbag (1.0.0)
       nokogiri (~> 1.8, >= 1.8.2)
     feedjira (3.2.2)
@@ -163,9 +164,8 @@ GEM
     minitest (5.22.2)
     msgpack (1.7.2)
     multi_json (1.15.0)
+    multipart-post (2.4.0)
     mutex_m (0.2.0)
-    net-http (0.4.1)
-      uri
     net-imap (0.4.9.1)
       date
       net-protocol
@@ -283,7 +283,6 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uri (0.13.0)
     web-console (4.2.1)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -312,6 +311,7 @@ DEPENDENCIES
   debug
   dotenv
   faraday
+  faraday_middleware
   feedbag
   feedjira
   googleauth

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -100,9 +100,9 @@ class Channel < ApplicationRecord
       end
 
     entries.sort_by(&:published).each do |entry|
-      p ["Fetching", entry.published, entry.title, entry.url]
+      sleep 2
 
-      sleep 3
+      p ["Fetching", entry.published, entry.title, entry.url]
 
       og = OpenGraph.new(entry.url)
       parameters = {


### PR DESCRIPTION
### リダイレクト対応

フィードの中では https://example.com/article1 を示していても、実際にアクセスすると https://example.com/article1/ のように末尾スラッシュありのページにリダイレクトされたりする。ってことがわかった。

FaradayMiddleware の FollowRedirects を使って、リダイレクトされる場合にも対象サイトの情報を取得できるようにする。

### og:image パース方法変更

og:image のパース方法を変えたら、今まで情報を取得できなかったサイトでも取得できるようになった (？)
