### PR TITLE
新着 Item の通知処理をもっともっといい感じにしたい

### DIFF
--- a/app/jobs/item_creation_notifier_job.rb
+++ b/app/jobs/item_creation_notifier_job.rb
@@ -21,6 +21,9 @@ class ItemCreationNotifierJob < ApplicationJob
   def should_notify?(item)
     channel = item.channel
 
+    # ChannelのItemが直近30分間で5件以上つくられていたら通知しない
+    return false if channel.items.where("created_at > ?", 30.minutes.ago).count >= 5
+
     # Channel作成から一定以上の時間が経過しているものは、新着検知されたItemとみなして通知する
     return true if item.channel.created_at < 1.hour.ago
 


### PR DESCRIPTION
### あらすじ

- https://github.com/kairan-app/feeeed/pull/13

### 改善ポイント

Channel は登録できたが、なんらかの理由で Item の保存はうまくいかないケースがある。処理を調整して Item の保存がうまくいくようになると、全 Item の分が Discord に通知されてしまってたいへんなので、同じ Channel からの Item 通知は 5 件まで、という制御を入れてみるぞ :dash:
