### PR TITLE
ActiveJob と Sidekiq の設定をそれっぽくする

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,7 +1,3 @@
 class ApplicationJob < ActiveJob::Base
-  # Automatically retry jobs that encountered a deadlock
-  # retry_on ActiveRecord::Deadlocked
-
-  # Most jobs are safe to ignore if the underlying records are no longer available
-  # discard_on ActiveJob::DeserializationError
+  queue_as :default
 end

--- a/app/jobs/channel_items_updater_job.rb
+++ b/app/jobs/channel_items_updater_job.rb
@@ -1,5 +1,5 @@
 class ChannelItemsUpdaterJob < ApplicationJob
-  queue_as :default
+  sidekiq_options retry: 2
 
   def perform(channel_id:, mode: :only_new)
     channel = Channel.find(channel_id)

--- a/app/jobs/item_creation_notifier_job.rb
+++ b/app/jobs/item_creation_notifier_job.rb
@@ -1,6 +1,4 @@
 class ItemCreationNotifierJob < ApplicationJob
-  queue_as :default
-
   def perform(item_id)
     webhook_url = ENV["DISCORD_WEBHOOK_URL"]
     return if webhook_url.nil?

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,5 @@
+require "sidekiq/web"
+
+Sidekiq::Web.use(Rack::Auth::Basic) do |user, password|
+  [user, password] == [ENV["SIDEKIQ_WEB_BASIC_AUTH_USER"], ENV["SIDEKIQ_WEB_BASIC_AUTH_PASSWORD"]]
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,8 @@
 Rails.application.routes.draw do
   get "/up" => "rails/health#show", as: :rails_health_check
 
-  if Rails.env.development?
-    require "sidekiq/web"
-    mount Sidekiq::Web => "/sidekiq"
-  end
+  require "sidekiq/web"
+  mount Sidekiq::Web => "/sidekiq"
 
   post   "/google_auth_callback",              to: "sessions#create"
   delete "/session",                           to: "sessions#destroy",     as: "session"

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,5 @@
+---
+:concurrency: 5
+:queues:
+  - default
+:max_retries: 5


### PR DESCRIPTION
- ログを見ていて「リトライしすぎでは？」と思うことがあったので、設定を見直したい
- sidekiq/web を Production 環境でも有効にする (認証は設定する)

これでウェブのダッシュボードにアクセスできるようになるので、様子を見ながら運用していこ〜 :nerd_face:
