### PR TITLE
YouTube の HTML は ASCII-8BIT として扱われるようなので、明示的に UTF-8 として扱う

### DIFF
--- a/lib/open_graph.rb
+++ b/lib/open_graph.rb
@@ -12,7 +12,7 @@ class OpenGraph
       c.use FaradayMiddleware::FollowRedirects
     end
 
-    @html = Nokogiri::HTML(connection.get(uri.path).body)
+    @html = Nokogiri::HTML(connection.get(uri.path).body.force_encoding("UTF-8"))
     @title = @html.css("title").text
 
     metas = @html.css("meta")


### PR DESCRIPTION
- Fix https://github.com/kairan-app/feeeed/issues/63
