### PR TITLE
Google のアカウントを一意に特定する ID を保存する

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -10,6 +10,7 @@ class SessionsController < ApplicationController
       aud: Rails.application.credentials.google_auth_app.client_id
     )
     user = User.find_or_initialize_by(email: payload["email"])
+    user.google_guid = payload["sub"]
     user.name ||= payload["email"].split("@").first
     user.icon_url = payload["picture"]
     user.save

--- a/db/migrate/20240224150007_add_google_guid_column_to_users.rb
+++ b/db/migrate/20240224150007_add_google_guid_column_to_users.rb
@@ -1,0 +1,5 @@
+class AddGoogleGuidColumnToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :google_guid, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_23_121712) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_24_150007) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -85,6 +85,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_23_121712) do
     t.string "icon_url", limit: 2083, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "google_guid"
   end
 
   add_foreign_key "channel_stoppers", "channels"


### PR DESCRIPTION
### やること

とりあえずで実装した Google 認証では、アカウントのキー情報をメールアドレスにしていた。これだと、利用者がメールアドレスを変更したときに (今はまだメールアドレスの変更機能はないけど) Google アカウントとの紐付けが破綻してしまう。

なので、まじめに ID っぽい情報をキーとして扱うようにします。

>これらのクレームを取得した後、aud クレームにアプリのクライアント ID の 1 つが含まれていることを確認する必要があります。含まれている場合、トークンは有効で、クライアント用のものであるため、ユーザーの一意の Google ID を sub クレームから安全に取得して使用できます。
>https://developers.google.com/identity/sign-in/web/backend-auth

によれば、payload に含まれる「sub」という項目が一意の Google ID に相当するとのことで、これを保存することにします。

### ちなみに

Production 環境では、この ID を保存せずにログインさせてしまっているので、利用者の全員の ID をデータベースに収集するまでは今回追加するカラムに NOT NULL 制約をかけることができません。

- この Pull Request をマージして、Production 環境で db:migrate を行う
- すべての利用者にログアウト→ログインを行ってもらう
- 追加の Pull Request でカラムに NOT NULL 制約や UNIQUE 制約を適切に設定する

といった順番で進めていくつもりです。今後ログインする利用者については、初回ログイン時に ID を必ず保存するのでなにも問題はありません。
