### PR TITLE
スタイリング @ 2024-03-04

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -19,6 +19,12 @@
 
 body {
   background-color: #feeeed;
+  font-family:
+    "Helvetica Neue",
+    "Arial",
+    "Hiragino Kaku Gothic ProN",
+    "Hiragino Sans",
+    sans-serif;
   word-break: break-all;
 }
 


### PR DESCRIPTION
フォント設定がない状態だとiPhone Safariで明朝体で表示されるので、ひとまずゴシック系でよしなに表示される設定だけしてみました🎨