### PR TITLE
Cookie を受け入れながら Faraday で get する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem "rails", "~> 7.1.3"
 gem "bootsnap", require: false
 gem "faraday"
 gem "faraday_middleware"
+gem "faraday-cookie_jar"
 gem "feedbag"
 gem "feedjira"
 gem "googleauth"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,7 @@ GEM
     debug (1.9.1)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    domain_name (0.6.20240107)
     dotenv (3.1.0)
     drb (2.2.1)
     erubi (1.12.0)
@@ -114,6 +115,9 @@ GEM
       faraday-rack (~> 1.0)
       faraday-retry (~> 1.0)
       ruby2_keywords (>= 0.0.4)
+    faraday-cookie_jar (0.0.7)
+      faraday (>= 0.8.0)
+      http-cookie (~> 1.0.0)
     faraday-em_http (1.0.0)
     faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
@@ -143,6 +147,8 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
+    http-cookie (1.0.5)
+      domain_name (~> 0.5)
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
     importmap-rails (2.0.1)
@@ -330,6 +336,7 @@ DEPENDENCIES
   debug
   dotenv
   faraday
+  faraday-cookie_jar
   faraday_middleware
   feedbag
   feedjira

--- a/lib/open_graph.rb
+++ b/lib/open_graph.rb
@@ -8,8 +8,9 @@ class OpenGraph
 
   def fetch_and_parse
     uri = URI.parse(@url)
-    connection = Faraday.new(uri) do |c|
-      c.use FaradayMiddleware::FollowRedirects
+    connection = Faraday.new(uri) do |builder|
+      builder.response :follow_redirects
+      builder.use :cookie_jar
     end
 
     @html = Nokogiri::HTML(connection.get(uri.path).body.force_encoding("UTF-8"))


### PR DESCRIPTION
### 具体的に起こっていた問題

https://note.com/fukkyy/rss というフィードに含まれる Item に https://note.com/fukkyy/n/n4166e9e642b0 という link を持つものがあり、これに Faraday からアクセスして情報を取得しようとすると too many redirects でエラーとなってしまう問題があった。

```
/usr/local/bundle/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response/follow_redirects.rb:83:in `block in perform_with_redirection': too many redirects; last one to: https://note.com/cd/sessions?redirect_to=https://comemo.nikkei.com/n/n4166e9e642b0&m=G%2BXI03QNhsPd9V2G1HmceWLNde/6kFVoy/3npJ/sI5zRNS5F9hPxYKevYoXNnlfx (FaradayMiddleware::RedirectLimitReached)
```

もともと follow redirects する処理にはなっていたが、note.com のセッション管理があって、クライアントサイド Cookie を受け入れないと延々とリダイレクトされてしまうようだった。

### 解決策

クライアントサイドを Cookie を受け入れる :cookie:
