### PR TITLE
フィードの中の entry が url を持っていない場合は、Channel の site_url で代替する

### DIFF
--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -104,7 +104,8 @@ class Channel < ApplicationRecord
 
       p ["Fetching", entry.published, entry.title, entry.url]
 
-      encoded_url = entry.url.chars.map { |c| c.bytesize > 1 ? URI.encode_www_form_component(c) : c }.join
+      url = entry.url || self.site_url
+      encoded_url = url.chars.map { |c| c.bytesize > 1 ? URI.encode_www_form_component(c) : c }.join
 
       og = OpenGraph.new(encoded_url)
       parameters = {


### PR DESCRIPTION
- https://github.com/kairan-app/feeeed/issues/53

たとえばブログのフィードにおいては、entry つまり記事が url を持っていない状況は想定しにくい。のだけれど、ポッドキャストのフィードにおいては entry の url は必須という雰囲気じゃなくて、音声ファイルのパスが enclosure url に設定されていればいいじゃん、というノリ。ポッドキャストのクライアントアプリは音声ファイルを再生できればよくて、そのエピソードに固有のウェブページがなくてもぜんぜん困らないもんね。

それくらいのノリなので、entry url が nil な場合は Channel の site_url を代わりに使うことにしてお茶を濁すぞ！だいたいの場合において、大した問題にならなそう〜。

「やっぱりこれじゃダメだよね」ってなったら Item モデルのスキーマから考え直します :dash:
