### PR TITLE
YouTube の場合は Video ID から画像 URL を生成する

### DIFF
--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -109,12 +109,18 @@ class Channel < ApplicationRecord
 
       guid = entry.entry_id || entry.url
 
-      og = OpenGraph.new(encoded_url)
+      image_url =
+        if guid.start_with?("yt:video:")
+          "https://img.youtube.com/vi/%s/maxresdefault.jpg" % guid.sub("yt:video:", "")
+        else
+          OpenGraph.new(encoded_url).image
+        end
+
       parameters = {
         guid: guid,
         title: entry.title,
         url: encoded_url,
-        image_url: og.image,
+        image_url: image_url,
         published_at: entry.published,
       }
       self.items.find_or_initialize_by(guid: parameters[:guid]).update(parameters)


### PR DESCRIPTION
動画ページにアクセスして og:image の値を取得する方式だと、ちょいちょい下の画像になっちゃうようなので :sweat_smile:

![maxresdefault](https://github.com/kairan-app/feeeed/assets/3970/10734b0a-ee39-4195-a33a-1192a9da2e7d)
