### PR TITLE
Item/Reaction の Discord 通知用の embed を組み立てる処理をメソッドにして共通化する

### DIFF
--- a/app/jobs/item_creation_notifier_job.rb
+++ b/app/jobs/item_creation_notifier_job.rb
@@ -4,21 +4,12 @@ class ItemCreationNotifierJob < ApplicationJob
     return if webhook_url.nil?
 
     item = Item.find(item_id)
-    channel = item.channel
 
     return unless should_notify?(item)
 
     content = "[#{Rails.env}] New item saved"
-    embeds = [
-      {
-        author: { name: channel.title, url: channel.site_url },
-        title: item.title,
-        description: URI.parse(item.url).host,
-        url: item.url,
-        thumbnail: { url: item.image_url },
-        timestamp: item.published_at.iso8601,
-      }
-    ]
+    p item.to_embed
+    embeds = [item.to_embed]
 
     Faraday.post(
       webhook_url, { content: , embeds: }.to_json, "Content-Type" => "application/json"
@@ -28,7 +19,7 @@ class ItemCreationNotifierJob < ApplicationJob
   def should_notify?(item)
     # 新しい方から見て3件以内のItemのみ通知する
     feed = Feedjira.parse(Faraday.get(item.channel.feed_url).body)
-    return true if item.guid.in?(feed.entries.sort_by(&:published).reverse.take(3).map(&:entry_id))
+    return true if item.guid.in?(feed.entries.sort_by(&:published).reverse.take(2).map(&:entry_id))
 
     false
   end

--- a/app/jobs/item_creation_notifier_job.rb
+++ b/app/jobs/item_creation_notifier_job.rb
@@ -8,7 +8,6 @@ class ItemCreationNotifierJob < ApplicationJob
     return unless should_notify?(item)
 
     content = "[#{Rails.env}] New item saved"
-    p item.to_embed
     embeds = [item.to_embed]
 
     Faraday.post(

--- a/app/jobs/reaction_creation_notifier_job.rb
+++ b/app/jobs/reaction_creation_notifier_job.rb
@@ -5,17 +5,9 @@ class ReactionCreationNotifierJob < ApplicationJob
 
     reaction = Reaction.find(reaction_id)
     user = reaction.user
-    item = reaction.item
 
     content = "@#{user.name} pawed!"
-    embeds = [
-      {
-        title: [item.title, item.channel.title].join(" | "),
-        description: reaction.memo.present? ? "💬 #{reaction.memo}" : nil,
-        url: item.url,
-        thumbnail: { url: item.image_url },
-      }
-    ]
+    embeds = [reaction.to_embed]
   
     Faraday.post(
       webhook_url, { content: "[#{Rails.env}] #{content}", embeds: }.to_json, "Content-Type" => "application/json"

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -15,4 +15,14 @@ class Item < ApplicationRecord
   def image_url_or_placeholder
     image_url.presence || "https://placehold.jp/30/cccccc/ffffff/270x180.png?text=#{self.title}"
   end
+
+  def to_embed
+    {
+      author: { name: [channel.title, URI.parse(self.url).host].join(" | "), url: channel.site_url },
+      title: self.title,
+      url: self.url,
+      thumbnail: { url: self.image_url },
+      timestamp: self.published_at.iso8601,
+    }
+  end
 end

--- a/app/models/notification_webhook.rb
+++ b/app/models/notification_webhook.rb
@@ -18,15 +18,7 @@ class NotificationWebhook < ApplicationRecord
     content = "@#{user.name}'s recent pawprints 🐾"
 
     reactions.find_in_batches(batch_size: 10) { |sub_reactions|
-      embeds =
-        sub_reactions.map { |reaction|
-          {
-            title: [reaction.item.title, reaction.item.channel.title].join(" | "),
-            description: reaction.memo.present? ? "💬 #{reaction.memo}" : nil,
-            url: reaction.item.url,
-            thumbnail: { url: reaction.item.image_url },
-          }
-        }
+      embeds = sub_reactions.map(&:to_embed)
 
       sleep 2
       Faraday.post(

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -7,4 +7,16 @@ class Reaction < ApplicationRecord
   validates :memo, length: { maximum: 300 }
 
   after_create_commit { ReactionCreationNotifierJob.perform_later(self.id) }
+
+  def to_embed
+    channel = item.channel
+    {
+      author: { name: [channel.title, URI.parse(item.url).host].join(" | "), url: channel.site_url },
+      title: item.title,
+      description: memo.present? ? "💬 #{memo}" : nil,
+      url: item.url,
+      thumbnail: { url: item.image_url },
+      timestamp: self.created_at.iso8601,
+    }
+  end
 end


### PR DESCRIPTION
通知処理ごとに embed のデータを組み立てていたので、Discord 上の表示がばらばらになっていました。メソッドにして共通化することで「Item は Item の見た目」「Reaction は Reaction の見た目」で整えていきます :sparkles:
