### PR TITLE
NotificationWebhook に mode を追加し、自分の Pawprints 以外も扱えるようにしていく

### DIFF
--- a/app/models/notification_webhook.rb
+++ b/app/models/notification_webhook.rb
@@ -3,6 +3,12 @@ class NotificationWebhook < ApplicationRecord
 
   validates :user_id, presence: true
   validates :url, presence: true, length: { maximum: 2083 }
+  validates :mode, presence: true
+
+  enum mode: {
+    my_subscribed_item: 0,
+    my_pawprints: 1,
+  }
 
   class << self
     def notify

--- a/app/models/notification_webhook.rb
+++ b/app/models/notification_webhook.rb
@@ -6,7 +6,7 @@ class NotificationWebhook < ApplicationRecord
   validates :mode, presence: true
 
   enum mode: {
-    my_subscribed_item: 0,
+    my_subscribed_items: 0,
     my_pawprints: 1,
   }
 

--- a/db/migrate/20240323063928_add_mode_column_to_notification_webhooks_table.rb
+++ b/db/migrate/20240323063928_add_mode_column_to_notification_webhooks_table.rb
@@ -1,0 +1,5 @@
+class AddModeColumnToNotificationWebhooksTable < ActiveRecord::Migration[7.1]
+  def change
+    add_column :notification_webhooks, :mode, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_18_085608) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_23_063928) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -54,6 +54,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_085608) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "last_notified_at"
+    t.integer "mode", default: 0, null: false
     t.index ["user_id"], name: "index_notification_webhooks_on_user_id"
   end
 


### PR DESCRIPTION
- これまでの NotificationWebhook は「自分の直近の Pawprints を対象とする」動作モードしかなかった
  - 最初に試運転したいのがそれだったので、まずそれを実装した
- ここで mode というカラムを追加して、動作モードを選べるようにしていく
  - これまで試運転してきたやつは `my_pawprints` とする
  - このあと `my_subscribed_items` という動作モードを追加するつもり
- もともと話していた通り「自分が購読している Channels の新着 Items を対象とする」動作モードを実装する準備
