### PR TITLE
運用者向けに種々のイベントを Discord に通知する

### DIFF
--- a/app/controllers/channels_controller.rb
+++ b/app/controllers/channels_controller.rb
@@ -18,6 +18,8 @@ class ChannelsController < ApplicationController
   def create
     url = params[:url]
 
+    Disco.post_content("@#{current_user.name} try to add #{url}")
+
     if channel = Channel.add(url)
       flash[:notice] = "Channel added successfully"
       redirect_to channel

--- a/app/controllers/notification_webhooks_controller.rb
+++ b/app/controllers/notification_webhooks_controller.rb
@@ -5,6 +5,7 @@ class NotificationWebhooksController < ApplicationController
     nw = current_user.notification_webhooks.new(notification_webhook_params)
 
     if nw.save
+      Disco.post_content("@#{current_user.name} added a notification webhook (mode: #{nw.mode})")
       redirect_to my_notification_webhooks_path, notice: "Notification webhook was successfully created."
     else
       redirect_to my_notification_webhooks_path, alert: nw.errors.full_messages.join(", ")

--- a/app/controllers/ownerships_controller.rb
+++ b/app/controllers/ownerships_controller.rb
@@ -4,6 +4,7 @@ class OwnershipsController < ApplicationController
 
   def create
     current_user.add_channel(@channel)
+    Disco.post_content("@#{current_user.name} added #{@channel.title} to their own")
 
     redirect_to @channel
   end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -4,6 +4,7 @@ class SubscriptionsController < ApplicationController
 
   def create
     current_user.subscribe(@channel)
+    Disco.post_content("@#{current_user.name} subscribed to #{@channel.title}")
 
     redirect_to @channel
   end

--- a/app/jobs/item_creation_notifier_job.rb
+++ b/app/jobs/item_creation_notifier_job.rb
@@ -1,8 +1,5 @@
 class ItemCreationNotifierJob < ApplicationJob
   def perform(item_id)
-    webhook_url = ENV["DISCORD_WEBHOOK_URL"]
-    return if webhook_url.nil?
-
     item = Item.find(item_id)
 
     return unless should_notify?(item)
@@ -10,9 +7,7 @@ class ItemCreationNotifierJob < ApplicationJob
     content = "[#{Rails.env}] New item saved"
     embeds = [item.to_embed]
 
-    Faraday.post(
-      webhook_url, { content: , embeds: }.to_json, "Content-Type" => "application/json"
-    )
+    Disco.post({ content: , embeds: })
   end
 
   def should_notify?(item)

--- a/app/jobs/pawprint_creation_notifier_job.rb
+++ b/app/jobs/pawprint_creation_notifier_job.rb
@@ -1,16 +1,11 @@
 class PawprintCreationNotifierJob < ApplicationJob
   def perform(pawprint_id)
-    webhook_url = ENV["DISCORD_WEBHOOK_URL"]
-    return if webhook_url.nil?
-
     pawprint = Pawprint.find(pawprint_id)
     user = pawprint.user
 
     content = "@#{user.name} pawed!"
     embeds = [pawprint.to_embed]
-  
-    Faraday.post(
-      webhook_url, { content: "[#{Rails.env}] #{content}", embeds: }.to_json, "Content-Type" => "application/json"
-    )
+
+    Disco.post({ content: "[#{Rails.env}] #{content}", embeds: })
   end
 end

--- a/lib/disco.rb
+++ b/lib/disco.rb
@@ -1,0 +1,30 @@
+module Disco
+  class << self
+    def post(payload)
+      webhook_url = ENV["DISCORD_WEBHOOK_URL"]
+      return if webhook_url.nil?
+
+      response = Faraday.post(webhook_url) do |req|
+        req.headers["Content-Type"] = "application/json"
+        req.body = payload.to_json
+      end
+      handle_response(response)
+    end
+
+    def post_content(content)
+      payload = { content: content }
+      post(payload)
+    end
+
+    private
+
+    def handle_response(response)
+      case response.status
+      when 200..299
+        puts "Message sent successfully"
+      else
+        puts "Error sending message: #{response.body}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
下記のイベントを Discord に通知するように処理を追加します :v:

- 利用者が Channel を登録しようとしたとき
- 利用者が Channel を Subscribe するとき
- 利用者が Channel を Add to my own するとき
- 利用者が NotificationWebhook を追加するとき

それに先立って、Discord 通知用のモジュールを導入し、既存の通知処理を整理します :muscle:
