### PR TITLE
新着 Item の Discord 通知にて、Rails.env の情報はナシでいいか

### DIFF
--- a/app/jobs/item_creation_notifier_job.rb
+++ b/app/jobs/item_creation_notifier_job.rb
@@ -4,7 +4,7 @@ class ItemCreationNotifierJob < ApplicationJob
 
     return unless should_notify?(item)
 
-    content = "[#{Rails.env}] New item saved"
+    content = "New item saved"
     embeds = [item.to_embed]
 
     DiscoPosterJob.perform_later(content:, embeds:)


### PR DESCRIPTION
もともと Development と Production で同じチャンネルに通知していて、そのときに見分けがつくといいな〜と思って Rails.env の情報を付与していました。

しかし、開発が進んでからは、Development での通知は自分だけがアクセスできるチャンネルに向けることでチームメンバーに影響を与えずに済むのでそっちの方がいいねってことで定着しています。なので Rails.env を抜いてみます。
