### PR TITLE
Unreadsページのスタイリング

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -858,7 +858,6 @@ img {
   }
 }
 
-
 .setting-list input[type="submit"i] {
   padding: 0.25em 1em;
   background-color: #333333;
@@ -866,4 +865,112 @@ img {
   border: none;
   border-radius: 16px;
   cursor: pointer;
+}
+
+.unreads-component {
+  margin: 20px 20px 20px 0;
+  border-top: 1px solid #999;
+}
+
+@media screen and (max-width: 768px) {
+  .unreads-component {
+    margin: 20px 0;
+  }
+}
+
+.unreads-channel {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: left;
+  align-items: center;
+
+  img {
+    width: 64px;
+    height: 64px;
+    object-fit: cover;
+    margin-right: 10px;
+  }
+
+  span {
+    display: inline-block;
+    width: calc(100% - 74px);
+  }
+}
+
+.unreads-item-list li {
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  margin: 0;
+  padding: 0.75em 0em;
+  border-top: 0.5px solid #dddddd;
+  line-height: 1.5em;
+}
+
+@media screen and (max-width: 768px) {
+  .unreads-item-list li {
+    padding: 1em 0em;
+  }
+}
+
+.unreads-item-image {
+  width: 96px;
+  height: 64px;
+  margin: 0 10px 0 0;
+
+  img {
+    object-fit: cover;
+  }
+}
+
+@media screen and (max-width: 768px) {
+  .unreads-item-image {
+    width: 96px;
+    height: 64px;
+    margin: 0 10px 8px 0;
+  }
+}
+
+.unreads-item-info {
+  width: calc(50% - 86px);
+  margin: 0 20px 0 0;
+}
+
+@media screen and (max-width: 768px) {
+  .unreads-item-info {
+    width: calc(100% - 106px);
+    margin: 0;
+  }
+}
+
+.unreads-item-skip {
+  position: relative;
+  top: 0px;
+  right: 0px;
+  width: 58px;
+}
+
+.unreads-item-skip a {
+  display: inline-block;
+  width: 50px;
+  padding: 6px 0px;
+  text-align: center;
+  background-color: #999999;
+  color: #ffffff;
+  border-radius: 2px;
+}
+
+.unreads-item-memo {
+  width: calc(50% - 100px);
+}
+
+@media screen and (max-width: 768px) {
+  .unreads-item-memo {
+    width: calc(100% - 58px);
+  }
+}
+
+.unreads-item-memo p {
+  background-color: #ffffff;
+  padding: 0.75em 1em;
 }

--- a/app/views/items/_pawprint_form.html.erb
+++ b/app/views/items/_pawprint_form.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag(id_of_pawprint_form_for(item)) do %>
   <%= form_tag(item_pawprint_path(item), method: :post) do %>
     <%= hidden_field_tag(:form_mode, "pawprint_form") %>
-    <%= text_field_tag(:memo, pawprint&.memo, placeholder: "Memo", style: "width: 80%; padding: 4px 8px;") %>
+    <%= text_field_tag(:memo, pawprint&.memo, placeholder: "Memo", style: "width: calc(100% - 41px); padding: 4px 8px;") %>
     <% image_file_name = pawprint ? "paw-on.png" : "paw-off.png" %>
     <%= image_submit_tag(image_file_name, width: "36px", height: "36px", style: "vertical-align: top;") %>
   <% end %>

--- a/app/views/my/unreads/show.html.erb
+++ b/app/views/my/unreads/show.html.erb
@@ -7,34 +7,34 @@
     <%= link_to((@days_before + 1).to_s + " days", unreads_path(days_before: @days_before + 1)) %>
   </p>
   <% @channel_and_items.each do |channel, items| %>
-    <div style="margin-bottom: 20px; border-bottom: 1px solid #999;">
-      <h3>
+    <div class="unreads-component">
+      <h3 class="unreads-channel">
         <% if channel.image_url %>
-        <%= image_tag(channel.image_url, size: "64x64", style: "margin-right: 6px;") %>
+        <%= image_tag(channel.image_url, size: "64x64",) %>
         <% end %>
-        <span style="display: inline-block; line-height: 64px; vertical-align: top;">
+        <span>
           <%= link_to(channel.title, channel) %>
         </span>
       </h3>
-      <ul>
+      <ul class="unreads-item-list">
         <% items.sort_by(&:published_at).reverse.take(6).each do |item| %>
           <%= turbo_frame_tag(item) do %>
-          <li style="position:relative; margin-bottom: 16px;">
-            <div style="position: absolute; top: 0; left: 0; width: 96px; height: 54px; display: inline-block; margin-right: 6px;">
+          <li>
+            <div class="unreads-item-image">
               <%= image_tag(item.image_url_or_placeholder, width: "100%", height: "100%", style: "object-fit: cover;") %>
             </div>
-            <div style="padding-left: 106px">
-              <h4 style="width: 80%;">
-                <%= link_to(item.title, item.url, target: "_blank") %>
-              </h4>
-              <div style="position: relative; width: 80%;">
-                <p style="margin-bottom: 6px; font-size: 90%; color: #666;">
-                  <%= item.published_at.strftime("%Y-%m-%d %H:%M") %>
-                </p>
-                <%= link_to("Skip", item_skip_path(item), data: { turbo_method: :post }, style: "position: absolute; top: 0; right: 0;") %>
-              </div>
-              <%= render(partial: "items/pawprint_form", locals: { item: item, pawprint: nil }) %>
-            </div>
+          <div class="unreads-item-info">
+            <h4>
+            <%= link_to(item.title, item.url, target: "_blank") %>
+            </h4>
+            <%= item.published_at.strftime("%Y-%m-%d %H:%M") %>
+          </div>
+          <div class="unreads-item-skip">
+            <%= link_to("Skip", item_skip_path(item), data: { turbo_method: :post }) %>
+          </div>
+          <div class="unreads-item-memo">
+            <%= render(partial: "items/pawprint_form", locals: { item: item, pawprint: nil }) %>
+          </div>
           </li>
           <% end %>
         <% end %>


### PR DESCRIPTION
コミットメッセージの通り、UnreadsページのレイアウトをPawprintsページに寄せる形で調整してみました🎨
Skipボタンの位置は悩ましいのだけど、ひとまず整理してここかなという位置に…！

この調整を皮切りに、トップページでも Channel & Item のセットで表示するようにしたり、 Unreads ページで juneboku さんがセットしてくれた Paw 画像を別のページでも使ったり、というのを後日やっていきたい🚀