### PR TITLE
トップページに Channel & Items のコンポーネントを表示させる

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -867,18 +867,18 @@ img {
   cursor: pointer;
 }
 
-.unreads-component {
+.channel-and-items-component {
   margin: 20px 20px 20px 0;
   border-top: 1px solid #999;
 }
 
 @media screen and (max-width: 768px) {
-  .unreads-component {
+  .channel-and-items-component {
     margin: 20px 0;
   }
 }
 
-.unreads-channel {
+.channel-and-items-component-channel {
   display: flex;
   flex-wrap: wrap;
   justify-content: left;
@@ -897,7 +897,7 @@ img {
   }
 }
 
-.unreads-item-list li {
+.channel-and-items-component-item-list li {
   position: relative;
   display: flex;
   flex-wrap: wrap;
@@ -908,12 +908,12 @@ img {
 }
 
 @media screen and (max-width: 768px) {
-  .unreads-item-list li {
+  .channel-and-items-component-item-list li {
     padding: 1em 0em;
   }
 }
 
-.unreads-item-image {
+.channel-and-items-component-item-image {
   width: 96px;
   height: 64px;
   margin: 0 10px 0 0;
@@ -923,34 +923,34 @@ img {
   }
 }
 
-@media screen and (max-width: 768px) {
-  .unreads-item-image {
+@media screen and (max-width: 1200px) {
+  .channel-and-items-component-item-image {
     width: 96px;
     height: 64px;
     margin: 0 10px 8px 0;
   }
 }
 
-.unreads-item-info {
+.channel-and-items-component-item-info {
   width: calc(50% - 86px);
   margin: 0 20px 0 0;
 }
 
-@media screen and (max-width: 768px) {
-  .unreads-item-info {
+@media screen and (max-width: 1200px) {
+  .channel-and-items-component-item-info {
     width: calc(100% - 106px);
     margin: 0;
   }
 }
 
-.unreads-item-skip {
+.channel-and-items-component-item-skip {
   position: relative;
   top: 0px;
   right: 0px;
   width: 58px;
 }
 
-.unreads-item-skip a {
+.channel-and-items-component-item-skip a {
   display: inline-block;
   width: 50px;
   padding: 6px 0px;
@@ -960,17 +960,39 @@ img {
   border-radius: 2px;
 }
 
-.unreads-item-memo {
+.channel-and-items-component-item-memo {
   width: calc(50% - 100px);
 }
 
-@media screen and (max-width: 768px) {
-  .unreads-item-memo {
+@media screen and (max-width: 1200px) {
+  .channel-and-items-component-item-memo {
     width: calc(100% - 58px);
   }
 }
 
-.unreads-item-memo p {
+.channel-and-items-component-item-memo-welcome {
+  width: calc(50% - 40px);
+}
+
+@media screen and (max-width: 1200px) {
+  .channel-and-items-component-item-memo-welcome {
+    width: 100%;
+  }
+}
+
+.channel-and-items-component-item-memo p {
   background-color: #ffffff;
   padding: 0.75em 1em;
+}
+
+.channel-and-items-component-item-memo p.button-to-unpaw {
+  background-color: inherit;
+  text-align: right;
+  padding: 0.25em 0 0;
+}
+
+@media screen and (max-width: 1200px) {
+  .channel-and-items-component-item-memo p.button-to-unpaw {
+    padding: 0.25em 5px 0 0;
+  }
 }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -567,7 +567,7 @@ aside nav ul li a:hover {
 .wrapper {
   display: flex;
   flex-wrap: wrap;
-  margin: 0 auto 70px;
+  margin: 0 auto 50px;
   padding: 0;
   width: 100%;
   max-width: 1440px;
@@ -575,7 +575,7 @@ aside nav ul li a:hover {
 
 @media screen and (max-width: 768px) {
   .wrapper {
-    margin: 0 auto 70px;
+    margin: 0 auto 50px;
     padding: 0 0 50px;
     width: calc(100% - 40px);
   }
@@ -816,30 +816,6 @@ img {
   padding: 0.75em 1em;
 }
 
-.main-column {
-  width: calc(100% - 340px);
-  margin: 0 20px 0 0;
-}
-
-@media screen and (max-width: 768px) {
-  .main-column {
-    width: 100%;
-    margin: 0 0 0 0;
-  }
-}
-
-.sub-column {
-  width: 320px;
-}
-
-@media screen and (max-width: 768px) {
-  .sub-column {
-    width: 100%;
-    position: relative;
-    bottom: auto;
-  }
-}
-
 .sub-column .pawprint-info {
   width: calc(100% - 34px);
   margin: 0;
@@ -1008,14 +984,28 @@ img {
 }
 
 .channel-and-items-component {
-  margin: 20px 20px 20px 0;
-  border-top: 1px solid #999;
+  width: calc(33.33333% - 20px);
+  margin: 0 20px 20px 0;
+  padding: 0 20px;
+  background-color: #ffffff;
+  border-radius: 8px;
+}
+
+@media screen and (max-width: 1200px) {
+  .channel-and-items-component {
+    width: calc(50% - 20px);
+  }
 }
 
 @media screen and (max-width: 768px) {
   .channel-and-items-component {
-    margin: 20px 0;
+    width: 100%;
+    margin: 0 0 20px;
   }
+}
+
+.channel-and-items-component-unreads {
+  width: calc(100% - 20px);
 }
 
 .channel-and-items-component-channel {
@@ -1029,12 +1019,17 @@ img {
     height: 64px;
     object-fit: cover;
     margin-right: 10px;
+    outline: solid 1px #eeeeee;
   }
 
   span {
     display: inline-block;
     width: calc(100% - 74px);
   }
+}
+
+.channel-and-items-component-item-list {
+  margin: 1em 0 0.5em;
 }
 
 .channel-and-items-component-item-list li {
@@ -1060,6 +1055,7 @@ img {
 
   img {
     object-fit: cover;
+    outline: solid 1px #eeeeee;
   }
 }
 
@@ -1072,14 +1068,38 @@ img {
 }
 
 .channel-and-items-component-item-info {
-  width: calc(50% - 86px);
-  margin: 0 20px 0 0;
+  width: calc(100% - 106px);
+  margin: 0;
 }
 
 @media screen and (max-width: 1200px) {
   .channel-and-items-component-item-info {
     width: calc(100% - 106px);
     margin: 0;
+  }
+}
+
+.channel-and-items-component-item-info-unreads {
+  width: calc(50% - 126px);
+  margin: 0 20px 0 0;
+}
+
+@media screen and (max-width: 768px) {
+  .channel-and-items-component-item-info-unreads {
+    width: calc(100% - 106px);
+    margin: 0;
+  }
+}
+
+.channel-and-items-component-item-paw {
+  display: flex;
+  width: 50%;
+  margin: 10px 0 0;
+}
+
+@media screen and (max-width: 768px) {
+  .channel-and-items-component-item-paw {
+    width: 100%;
   }
 }
 
@@ -1101,22 +1121,12 @@ img {
 }
 
 .channel-and-items-component-item-memo {
-  width: calc(50% - 100px);
+  width: calc(100% - 60px);
 }
 
 @media screen and (max-width: 1200px) {
   .channel-and-items-component-item-memo {
     width: calc(100% - 58px);
-  }
-}
-
-.channel-and-items-component-item-memo-welcome {
-  width: calc(50% - 40px);
-}
-
-@media screen and (max-width: 1200px) {
-  .channel-and-items-component-item-memo-welcome {
-    width: 100%;
   }
 }
 

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,11 +1,13 @@
 class WelcomeController < ApplicationController
   def index
-    @channels = Channel.includes(:items).limit(10)
-    @channel_and_items_for_welcome = @channels.map do |channel|
-      [channel, channel.items.order(created_at: :desc).limit(3)]
-    end.sort_by { |channel, items| items.first&.created_at }.reverse.to_h
-    @pawprints = Pawprint.order(id: :desc).limit(30)
+    @channels =
+      Channel.
+        joins(:items).
+        select("channels.*, MAX(items.id) AS max_item_id").
+        group("channels.id").
+        order("max_item_id DESC").
+        limit(30)
 
-    @title = "Feed Network"
+    @title = "Enjoy feeds!"
   end
 end

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,8 +1,10 @@
 class WelcomeController < ApplicationController
   def index
-    @channels = Channel.order(id: :desc).limit(10)
-    @items = Item.preload(:pawprints).eager_load(:channel).order(published_at: :desc, title: :desc).limit(12)
-    @pawprints = Pawprint.order(id: :desc).limit(15)
+    @channels = Channel.includes(:items).limit(10)
+    @channel_and_items_for_welcome = @channels.map do |channel|
+      [channel, channel.items.order(created_at: :desc).limit(3)]
+    end.sort_by { |channel, items| items.first&.created_at }.reverse.to_h
+    @pawprints = Pawprint.order(id: :desc).limit(30)
 
     @title = "Feed Network"
   end

--- a/app/views/items/_pawprint.html.erb
+++ b/app/views/items/_pawprint.html.erb
@@ -3,7 +3,7 @@
     <% pawprint = item.pawprints.find_by(user: current_user) %>
 
     <%= form_tag(item_pawprint_path(item), method: :post) do %>
-      <%= text_field_tag(:memo, pawprint&.memo, placeholder: "Memo") %>
+      <%= text_field_tag(:memo, pawprint&.memo, placeholder: "Memo", style: "width: calc(100% - 58px); padding: 4px 8px;") %>
       <%= submit_tag("Paw!") %>
     <% end %>
 

--- a/app/views/my/unreads/show.html.erb
+++ b/app/views/my/unreads/show.html.erb
@@ -1,49 +1,49 @@
-<section>
-  <h2>Unreads</h2>
-  <p>Showing unreads from the last <%= @days_before %> days</p>
-  <p>
-    <%= link_to((@days_before - 1).to_s + " days", unreads_path(days_before: @days_before - 1)) %>
-    |
-    <%= link_to((@days_before + 1).to_s + " days", unreads_path(days_before: @days_before + 1)) %>
-  </p>
-  <% @channel_and_items.each do |channel, items| %>
-    <div class="channel-and-items-component">
-      <h3 class="channel-and-items-component-channel">
-        <% if channel.image_url %>
-        <%= image_tag(channel.image_url, size: "64x64",) %>
-        <% end %>
-        <span>
-          <%= link_to(channel.title, channel) %>
-        </span>
-      </h3>
-      <ul class="channel-and-items-component-item-list">
-        <% items.sort_by(&:published_at).reverse.take(6).each do |item| %>
-          <%= turbo_frame_tag(item) do %>
-          <li>
-            <div class="channel-and-items-component-item-image">
-              <%= image_tag(item.image_url_or_placeholder, width: "100%", height: "100%", style: "object-fit: cover;") %>
-            </div>
-          <div class="channel-and-items-component-item-info">
-            <h4>
-            <%= link_to(item.title, item.url, target: "_blank") %>
-            </h4>
-            <%= item.published_at.strftime("%Y-%m-%d %H:%M") %>
+<h2>Unreads</h2>
+<p>Showing unreads from the last <%= @days_before %> days</p>
+<p>
+  <%= link_to((@days_before - 1).to_s + " days", unreads_path(days_before: @days_before - 1)) %>
+  |
+  <%= link_to((@days_before + 1).to_s + " days", unreads_path(days_before: @days_before + 1)) %>
+</p>
+<% @channel_and_items.each do |channel, items| %>
+  <div class="channel-and-items-component channel-and-items-component-unreads">
+    <h3 class="channel-and-items-component-channel">
+      <% if channel.image_url %>
+      <%= image_tag(channel.image_url, size: "64x64",) %>
+      <% end %>
+      <span>
+        <%= link_to(channel.title, channel) %>
+      </span>
+    </h3>
+    <ul class="channel-and-items-component-item-list">
+      <% items.sort_by(&:published_at).reverse.take(6).each do |item| %>
+        <%= turbo_frame_tag(item) do %>
+        <li>
+          <div class="channel-and-items-component-item-image">
+            <%= image_tag(item.image_url_or_placeholder, width: "100%", height: "100%", style: "object-fit: cover;") %>
           </div>
+        <div class="channel-and-items-component-item-info channel-and-items-component-item-info-unreads">
+          <h4>
+          <%= link_to(item.title, item.url, target: "_blank") %>
+          </h4>
+          <%= item.published_at.strftime("%Y-%m-%d %H:%M") %>
+        </div>
+        <div class="channel-and-items-component-item-paw">
           <div class="channel-and-items-component-item-skip">
             <%= link_to("Skip", item_skip_path(item), data: { turbo_method: :post }) %>
           </div>
           <div class="channel-and-items-component-item-memo">
             <%= render(partial: "items/pawprint_form", locals: { item: item, pawprint: nil }) %>
           </div>
-          </li>
-          <% end %>
+        </div>
+        </li>
         <% end %>
-        <% if items.size > 6 %>
-          <p>
-            Check out more unreads on <%= link_to(channel.title, channel) %>
-          </p>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
-</section>
+      <% end %>
+      <% if items.size > 6 %>
+        <p>
+          Check out more unreads on <%= link_to(channel.title, channel) %>
+        </p>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/my/unreads/show.html.erb
+++ b/app/views/my/unreads/show.html.erb
@@ -7,8 +7,8 @@
     <%= link_to((@days_before + 1).to_s + " days", unreads_path(days_before: @days_before + 1)) %>
   </p>
   <% @channel_and_items.each do |channel, items| %>
-    <div class="unreads-component">
-      <h3 class="unreads-channel">
+    <div class="channel-and-items-component">
+      <h3 class="channel-and-items-component-channel">
         <% if channel.image_url %>
         <%= image_tag(channel.image_url, size: "64x64",) %>
         <% end %>
@@ -16,23 +16,23 @@
           <%= link_to(channel.title, channel) %>
         </span>
       </h3>
-      <ul class="unreads-item-list">
+      <ul class="channel-and-items-component-item-list">
         <% items.sort_by(&:published_at).reverse.take(6).each do |item| %>
           <%= turbo_frame_tag(item) do %>
           <li>
-            <div class="unreads-item-image">
+            <div class="channel-and-items-component-item-image">
               <%= image_tag(item.image_url_or_placeholder, width: "100%", height: "100%", style: "object-fit: cover;") %>
             </div>
-          <div class="unreads-item-info">
+          <div class="channel-and-items-component-item-info">
             <h4>
             <%= link_to(item.title, item.url, target: "_blank") %>
             </h4>
             <%= item.published_at.strftime("%Y-%m-%d %H:%M") %>
           </div>
-          <div class="unreads-item-skip">
+          <div class="channel-and-items-component-item-skip">
             <%= link_to("Skip", item_skip_path(item), data: { turbo_method: :post }) %>
           </div>
-          <div class="unreads-item-memo">
+          <div class="channel-and-items-component-item-memo">
             <%= render(partial: "items/pawprint_form", locals: { item: item, pawprint: nil }) %>
           </div>
           </li>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,6 +1,6 @@
 <div class="main-column">
   <h2>Recent Channel & Items</h2>
-  <% @channel_and_items_for_welcome.each do |channel, items| %>
+  <% @channels.each do |channel| %>
     <div class="channel-and-items-component">
       <h3 class="channel-and-items-component-channel">
         <% if channel.image_url %>
@@ -11,7 +11,7 @@
         </span>
       </h3>
       <ul class="channel-and-items-component-item-list">
-        <% items.sort_by(&:published_at).reverse.take(3).each do |item| %>
+        <% channel.items.order(id: :desc).limit(3).each do |item| %>
           <%= turbo_frame_tag(item) do %>
           <li>
             <div class="channel-and-items-component-item-image">
@@ -23,24 +23,10 @@
             </h4>
             <%= item.published_at.strftime("%Y-%m-%d %H:%M") %>
           </div>
-          <div class="channel-and-items-component-item-memo channel-and-items-component-item-memo-welcome">
-            <%= render(partial: "items/pawprint", locals: { item: item }) %>
-          </div>
           </li>
           <% end %>
         <% end %>
       </ul>
     </div>
   <% end %>
-
-</div>
-
-<div class="sub-column">
-  <section>
-    <h2>Recent Pawprints</h2>
-    <p>
-      <%= link_to("All Pawprints", pawprints_path) %>
-    </p>
-    <%= render(partial: "pawprints/lines", locals: { pawprints: @pawprints }) %>
-  </section>
 </div>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,32 +1,30 @@
-<div class="main-column">
-  <h2>Recent Channel & Items</h2>
-  <% @channels.each do |channel| %>
-    <div class="channel-and-items-component">
-      <h3 class="channel-and-items-component-channel">
-        <% if channel.image_url %>
-        <%= image_tag(channel.image_url, size: "64x64",) %>
-        <% end %>
-        <span>
-          <%= link_to(channel.title, channel) %>
-        </span>
-      </h3>
-      <ul class="channel-and-items-component-item-list">
-        <% channel.items.order(id: :desc).limit(3).each do |item| %>
-          <%= turbo_frame_tag(item) do %>
-          <li>
-            <div class="channel-and-items-component-item-image">
-              <%= image_tag(item.image_url_or_placeholder, width: "100%", height: "100%", style: "object-fit: cover;") %>
-            </div>
-          <div class="channel-and-items-component-item-info">
-            <h4>
-            <%= link_to(item.title, item.url, target: "_blank") %>
-            </h4>
-            <%= item.published_at.strftime("%Y-%m-%d %H:%M") %>
+<h2>Recent Channel & Items</h2>
+<% @channels.each do |channel| %>
+  <div class="channel-and-items-component">
+    <h3 class="channel-and-items-component-channel">
+      <% if channel.image_url %>
+      <%= image_tag(channel.image_url, size: "64x64",) %>
+      <% end %>
+      <span>
+        <%= link_to(channel.title, channel) %>
+      </span>
+    </h3>
+    <ul class="channel-and-items-component-item-list">
+      <% channel.items.order(id: :desc).limit(3).each do |item| %>
+        <%= turbo_frame_tag(item) do %>
+        <li>
+          <div class="channel-and-items-component-item-image">
+            <%= image_tag(item.image_url_or_placeholder, width: "100%", height: "100%", style: "object-fit: cover;") %>
           </div>
-          </li>
-          <% end %>
+        <div class="channel-and-items-component-item-info">
+          <h4>
+          <%= link_to(item.title, item.url, target: "_blank") %>
+          </h4>
+          <%= item.published_at.strftime("%Y-%m-%d %H:%M") %>
+        </div>
+        </li>
         <% end %>
-      </ul>
-    </div>
-  <% end %>
-</div>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,19 +1,38 @@
 <div class="main-column">
-  <section>
-    <h2>Recent Items</h2>
-    <p>
-      <%= link_to("All items", items_path) %>
-    </p>
-    <%= render(partial: "items/cards", locals: { items: @items, with_channel: true }) %>
-  </section>
+  <h2>Recent Channel & Items</h2>
+  <% @channel_and_items_for_welcome.each do |channel, items| %>
+    <div class="unreads-component">
+      <h3 class="unreads-channel">
+        <% if channel.image_url %>
+        <%= image_tag(channel.image_url, size: "64x64",) %>
+        <% end %>
+        <span>
+          <%= link_to(channel.title, channel) %>
+        </span>
+      </h3>
+      <ul class="unreads-item-list">
+        <% items.sort_by(&:published_at).reverse.take(3).each do |item| %>
+          <%= turbo_frame_tag(item) do %>
+          <li>
+            <div class="unreads-item-image">
+              <%= image_tag(item.image_url_or_placeholder, width: "100%", height: "100%", style: "object-fit: cover;") %>
+            </div>
+          <div class="unreads-item-info">
+            <h4>
+            <%= link_to(item.title, item.url, target: "_blank") %>
+            </h4>
+            <%= item.published_at.strftime("%Y-%m-%d %H:%M") %>
+          </div>
+          <div class="unreads-item-memo">
+            <%= render(partial: "items/pawprint", locals: { item: item }) %>
+          </div>
+          </li>
+          <% end %>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
 
-  <section>
-    <h2>Recent Channels</h2>
-    <p>
-      <%= link_to("All channels", channels_path) %>
-    </p>
-    <%= render(partial: "channels/cards", locals: { channels: @channels }) %>
-  </section>
 </div>
 
 <div class="sub-column">

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,8 +1,8 @@
 <div class="main-column">
   <h2>Recent Channel & Items</h2>
   <% @channel_and_items_for_welcome.each do |channel, items| %>
-    <div class="unreads-component">
-      <h3 class="unreads-channel">
+    <div class="channel-and-items-component">
+      <h3 class="channel-and-items-component-channel">
         <% if channel.image_url %>
         <%= image_tag(channel.image_url, size: "64x64",) %>
         <% end %>
@@ -10,20 +10,20 @@
           <%= link_to(channel.title, channel) %>
         </span>
       </h3>
-      <ul class="unreads-item-list">
+      <ul class="channel-and-items-component-item-list">
         <% items.sort_by(&:published_at).reverse.take(3).each do |item| %>
           <%= turbo_frame_tag(item) do %>
           <li>
-            <div class="unreads-item-image">
+            <div class="channel-and-items-component-item-image">
               <%= image_tag(item.image_url_or_placeholder, width: "100%", height: "100%", style: "object-fit: cover;") %>
             </div>
-          <div class="unreads-item-info">
+          <div class="channel-and-items-component-item-info">
             <h4>
             <%= link_to(item.title, item.url, target: "_blank") %>
             </h4>
             <%= item.published_at.strftime("%Y-%m-%d %H:%M") %>
           </div>
-          <div class="unreads-item-memo">
+          <div class="channel-and-items-component-item-memo channel-and-items-component-item-memo-welcome">
             <%= render(partial: "items/pawprint", locals: { item: item }) %>
           </div>
           </li>


### PR DESCRIPTION
トップページにある Channels 一覧と Items 一覧の代わりに、「1 Channel あたり最大 3 Items が格納されたコンポーネントを10個ほど表示（並び順は、 Item の created_at をキーに）」させたい。

…のですが、力不足で controller での設定が失敗しており意図した表示になっていない状態です😭
意図した表示では無いのですがスタイリングだけ進めて Draft PR の形でプッシュさせていただきました、 controller のところを見てもらえると嬉しいです🙏
