### PR TITLE
メニューまわり大改造🚀

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -29,12 +29,12 @@ body {
 }
 
 h1 {
-  margin: 1.25em 0 0.5em 20px;
+  margin: 0 0 0 20px;
 }
 
 @media screen and (max-width: 768px) {
   h1 {
-    margin: 1.25em 0 0;
+    margin: 0.25em 0 0;
   }
 }
 
@@ -65,18 +65,16 @@ a:hover {
 }
 
 .google-login {
-  position: fixed;
-  bottom: 20px;
-  left: 15px;
-  background-color: #ffffff;
-  padding: 15px 20px;
-  border-radius: 30px;
-  box-shadow: 0px 0px 8px -6px #555555;
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  padding: 0;
   z-index: 1;
 }
 
 @media screen and (max-width: 768px) {
   .google-login {
+    bottom: 60px;
     box-shadow: 0px 0px 8px -4px #555555;
   }
 }
@@ -148,7 +146,7 @@ a:hover {
 
 @media screen and (max-width: 768px) {
   .channel-registration-form-button {
-    bottom: 90px;
+    bottom: 88px;
   }
 }
 
@@ -213,6 +211,7 @@ a:hover {
 
 .flash-messages {
   display: inline-block;
+  width: 100%;
   margin: 1em 0 0;
   padding: 20px;
   background-color: #ffffff;
@@ -226,25 +225,65 @@ a:hover {
   color: #cc0f35;
 }
 
-.wrapper {
-  display: flex;
-  flex-wrap: wrap;
-  margin: 0 0 70px;
-  padding: 0;
+header {
+  position: relative;
   width: 100%;
+  max-width: 1440px;
+  display: flex;
+  margin: 0 auto;
+  z-index: 1;
 }
 
 @media screen and (max-width: 768px) {
-  .wrapper {
-    margin: 0 auto 70px;
-    padding: 0 0 50px;
+  header {
     width: calc(100% - 40px);
+    margin: 0 20px;
   }
 }
 
+header h1 {
+  width: 144px;
+  line-height: 72px;
+
+  img {
+    width: 100%;
+    height: auto;
+  }
+}
+
+header nav {
+  position: relative;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+}
+
+header nav ul {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  margin: 1em 72px 1em 0;
+  padding: 0;
+}
+
+header nav ul li a {
+  position: relative;
+  display: block;
+  margin: 0 1em 0 0;
+  padding: 0.5em 0 0.5em 2em;
+}
+
+header nav ul li a:hover {
+  text-decoration: none;
+  background-color: rgba(255, 255, 255, 0.5);
+}
+
+
+
 aside {
   position: fixed;
-  width: 240px;
+  width: calc(100% - 240px);
 }
 
 @media screen and (max-width: 768px) {
@@ -306,6 +345,10 @@ aside nav ul li a:hover {
   font-weight: 100;
 }
 
+.nav-icon-home::before {
+  content: "\e88a";
+}
+
 .nav-icon-items::before {
   content: "\f009";
 }
@@ -346,28 +389,45 @@ aside nav ul li a:hover {
   content: "\eb92";
 }
 
-/* Hamburger Menu for Smatrphone */
-@media screen and (max-width: 768px) {
-  .hamburger-menu-list {
-    position: fixed;
-    top: 0;
-    left: 0;
-    display: flex;
-    align-items: flex-start;
-    flex-direction: column;
-    width: 100%;
-    margin: 0;
-    padding: 20px;
-    background-color: #ffffff;
-    transform: translateY(-100%);
-    transition: 0.3s;
-    z-index: 2;
-  }
+.nav-icon-logout::before {
+  content: "\e9ba";
+}
 
-  #hamburger:checked~.hamburger-menu-list {
-    transform: translateY(0%);
-    transition: 0.3s;
-  }
+/* Hamburger Menu for Setting */
+.hamburger-menu-list {
+  position: absolute;
+  top: 55px;
+  right: 10px;
+  display: flex;
+  align-items: flex-start;
+  flex-direction: column;
+  width: auto;
+  margin: 0;
+  padding: 0;
+  background-color: #ffffff;
+  transform: translateY(calc(-100% - 50px));
+  transition: 0s;
+  z-index: 0;
+  opacity: 0.2;
+  box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.1);
+  border-radius: 2px;
+}
+
+#hamburger:checked~.hamburger-menu-list {
+  transform: translateY(0%);
+  transition: 0s;
+  z-index: 2;
+  opacity: 1;
+}
+
+.hamburger-menu-list li {
+  width: 100%;
+  padding: 5px;
+  border-bottom: solid 1px #cccccc;
+}
+
+.hamburger-menu-list li:last-child {
+  border-bottom: solid 0px #cccccc;
 }
 
 .hamburger-menu-input {
@@ -386,33 +446,37 @@ aside nav ul li a:hover {
   width: calc(100% + 40px);
   height: 100vh;
   background-color: #000000;
-  opacity: 0.4;
+  opacity: 0;
   z-index: 2;
 }
 
 .hamburger-menu-button {
-  display: none;
+  position: absolute;
+  top: 14pt;
+  right: 18px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 5px;
+  appearance: none;
+  background-color: #ffffff;
+  box-shadow: 0px 0px 8px -4px #555555;
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  z-index: 2;
+
+  img {
+    width: 36px;
+    height: auto;
+    border-radius: 24px;
+  }
 }
 
 @media screen and (max-width: 768px) {
   .hamburger-menu-button {
-    position: fixed;
-    bottom: 20px;
-    right: 20px;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    width: 54px;
-    height: 54px;
-    gap: 5px;
-    appearance: none;
-    background-color: #ffffff;
-    box-shadow: 0px 0px 8px -4px #555555;
-    border: none;
-    border-radius: 50%;
-    cursor: pointer;
-    z-index: 2;
+    right: 0px;
   }
 }
 
@@ -424,27 +488,104 @@ aside nav ul li a:hover {
   transition: 0.3s;
 }
 
+#hamburger:checked~.hamburger-menu-button .hamburger-menu-button-mark:nth-of-type(1) {
+  transform: translate(3px, -1px) rotate(45deg);
+  transform-origin: 0%;
+}
+
+#hamburger:checked~.hamburger-menu-button .hamburger-menu-button-mark:nth-of-type(2) {
+  opacity: 0;
+}
+
+#hamburger:checked~.hamburger-menu-button .hamburger-menu-button-mark:nth-of-type(3) {
+  transform: translate(3px, 1px) rotate(-45deg);
+  transform-origin: 0%;
+}
+
+/* Menu for PC */
 @media screen and (max-width: 768px) {
-  #hamburger:checked~.hamburger-menu-button .hamburger-menu-button-mark:nth-of-type(1) {
-    transform: translate(3px, -1px) rotate(45deg);
-    transform-origin: 0%;
+  .pc-menu {
+    display: none;
+  }
+}
+
+/* Tab for Smatrphone */
+.sp-tab {
+  display: none;
+}
+
+@media screen and (max-width: 768px) {
+  .sp-tab {
+    position: fixed;
+    bottom: 0;
+    display: block;
+    width: 100%;
+    height: 72px;
+    margin: 0 0 0 -20px;
+    padding: 0;
+    background-color: #3d8bcd;
+    color: #ffffff;
+    z-index: 1;
   }
 
-  #hamburger:checked~.hamburger-menu-button .hamburger-menu-button-mark:nth-of-type(2) {
-    opacity: 0;
+  .sp-tab ul {
+    display: flex;
+    justify-content: space-evenly;
+    width: 100%;
+    height: 72px;
+    margin: 0;
+    padding: 0;
   }
 
-  #hamburger:checked~.hamburger-menu-button .hamburger-menu-button-mark:nth-of-type(3) {
-    transform: translate(3px, 1px) rotate(-45deg);
-    transform-origin: 0%;
+  .sp-tab ul li {
+    width: 33.33333%;
+    text-align: center;
+  }
+
+  .sp-tab ul li .nav-icon {
+    display: block;
+    width: 100%;
+    height: 72px;
+    margin: 0;
+    padding: 48px 0 0;
+    font-size: 10px;
+    color: #ffffff;
+  }
+
+  .sp-tab ul li .nav-icon::before {
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    padding: 0 0 0 0;
+    font-size: 36px;
+    color: #ffffff;
+    font-weight: 100;
+  }
+}
+
+.wrapper {
+  display: flex;
+  flex-wrap: wrap;
+  margin: 0 auto 70px;
+  padding: 0;
+  width: 100%;
+  max-width: 1440px;
+}
+
+@media screen and (max-width: 768px) {
+  .wrapper {
+    margin: 0 auto 70px;
+    padding: 0 0 50px;
+    width: calc(100% - 40px);
   }
 }
 
 .main {
   display: flex;
   flex-wrap: wrap;
-  width: calc(100% - 240px);
-  margin: 0 0 0 240px;
+  width: calc(100% - 20px);
+  margin: 0 0 0 20px;
 }
 
 @media screen and (max-width: 768px) {
@@ -495,15 +636,6 @@ aside nav ul li a:hover {
 }
 
 .channel-card {
-  width: calc(16.66666% - 15px);
-
-  img {
-    width: 100%;
-    height: 100%;
-  }
-}
-
-.item-card {
   width: calc(20% - 15px);
 
   img {
@@ -512,13 +644,12 @@ aside nav ul li a:hover {
   }
 }
 
-@media screen and (max-width: 1440px) {
-  .channel-card {
-    width: calc(20% - 15px);
-  }
+.item-card {
+  width: calc(25% - 15px);
 
-  .item-card {
-    width: calc(25% - 15px);
+  img {
+    width: 100%;
+    height: 100%;
   }
 }
 
@@ -973,4 +1104,46 @@ img {
 .unreads-item-memo p {
   background-color: #ffffff;
   padding: 0.75em 1em;
+}
+
+.channel_search {
+  margin: 0 10px 0 30px;
+}
+
+.channel_search input {
+  padding: 0.25em 0.5em;
+  border: solid 1px #cccccc;
+}
+
+footer {
+  width: 100%;
+  padding: 2em 0;
+  background-color: #3d8bcd;
+  color: #ffffff;
+  text-align: center;
+}
+
+@media screen and (max-width: 768px) {
+  footer {
+    padding: 2em 0 100px;
+  }
+}
+
+footer ul {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  margin: 0 0 1em;
+  padding: 0;
+}
+
+footer ul li {
+  margin: 0 1em;
+  padding: 0;
+}
+
+
+footer ul li a {
+  color: #ffffff;
 }

--- a/app/views/channels/_search_form.html.erb
+++ b/app/views/channels/_search_form.html.erb
@@ -1,4 +1,4 @@
   <%= search_form_for(q || Channel.ransack, url: channels_path) do |form| %>
-    <%= form.search_field(:title_or_description_or_site_url_or_feed_url_cont) %>
-    <%= form.submit("Search Channels") %>
+    <%= form.search_field(:title_or_description_or_site_url_or_feed_url_cont, placeholder: "Search Channels") %>
+    <%= form.submit("Search") %>
   <% end %>

--- a/app/views/layouts/_google_login.html.erb
+++ b/app/views/layouts/_google_login.html.erb
@@ -1,10 +1,5 @@
+<% unless logged_in? %>　　　　　　　　
 <div class="google-login">
-<% if logged_in? %>
-  <p>
-    <%= link_to(image_tag(current_user.icon_url, size: "24x24", style: "border-radius: 50%; vertical-align: top; margin-right: 5px;"), user_path(current_user.name)) %>
-    <%= link_to("Log out", session_path, data: { turbo_method: :delete }, style: "display: inline-block; line-height: 24px;") %>
-  </p>
-<% else %>
   <script src="https://accounts.google.com/gsi/client" async defer></script>
   <div id="g_id_onload"
      data-client_id="<%= Rails.application.credentials.google_auth_app.client_id %>"
@@ -19,5 +14,5 @@
      data-shape="rectangular"
      data-logo_alignment="left">
   </div>
-<% end %>
 </div>
+<% end %>

--- a/app/views/layouts/_menu.html.erb
+++ b/app/views/layouts/_menu.html.erb
@@ -1,25 +1,31 @@
 <nav>
+  <%= render(partial: "channels/search_form", locals: { q: @q }) %>
+
+  <% if logged_in? %>
+  <ul class="pc-menu">
+    <li><%= link_to("Unreads", unreads_path, class: 'nav-icon nav-icon-my-inbox') %></li>
+    <li><%= link_to("Settings", my_path, class: 'nav-icon nav-icon-setting') %></li>
+  </ul>
+
   <input type="checkbox" name="hamburger" id="hamburger" class="hamburger-menu-input"/>
   <label for="hamburger" class="hamburger-menu-bg"></label>
   <ul class="hamburger-menu-list">
-    <li><%= link_to("Channels", channels_path, class: 'nav-icon nav-icon-channels') %></li>
-    <li><%= link_to("Items", items_path, class: 'nav-icon nav-icon-items') %></li>
-    <li><%= link_to("Pawprints", pawprints_path, class: 'nav-icon nav-icon-pawprints') %></li>
-    <li><%= link_to("Users", users_path, class: 'nav-icon nav-icon-users') %></li>
-
-    <% if logged_in? %>
-    <li><%= link_to("Inbox", inbox_path, class: 'nav-icon nav-icon-my-inbox') %></li>
-    <li><%= link_to("Unreads", unreads_path, class: 'nav-icon nav-icon-my-inbox') %></li>
     <li><%= link_to("My Pawprints", my_pawprints_path, class: 'nav-icon nav-icon-my-pawprints') %></li>
-    <li><%= link_to("Settings", my_path, class: 'nav-icon nav-icon-setting') %></li>
-    <li><%= link_to("@#{current_user.name}", user_path(user_name: current_user.name), class: 'nav-icon nav-icon-my-profile') %></li>
-    <% end %>
-
-    <%= render(partial: "channels/search_form", locals: { q: @q }) %>
+    <li><%= link_to("My Page", user_path(user_name: current_user.name), class: 'nav-icon nav-icon-my-profile') %></li>
+    <li><%= link_to("Log out", session_path, data: { turbo_method: :delete }, class: 'nav-icon nav-icon-logout') %></li>
   </ul>
   <label for="hamburger" class="hamburger-menu-button">
-    <span class="hamburger-menu-button-mark"></span>
-    <span class="hamburger-menu-button-mark"></span>
-    <span class="hamburger-menu-button-mark"></span>
+    <%= image_tag(current_user.icon_url, size: "36x36") %>
   </label>
+  <% end %>
+</nav>
+
+<nav class="sp-tab">
+  <ul>
+    <li><%= link_to("Home", root_path, class: 'nav-icon nav-icon-home') %></li>
+    <% if logged_in? %>
+    <li><%= link_to("Unreads", unreads_path, class: 'nav-icon nav-icon-my-inbox') %></li>
+    <li><%= link_to("Settings", my_path, class: 'nav-icon nav-icon-setting') %></li>
+    <% end %>
+  </ul>
 </nav>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,17 +12,31 @@
   </head>
 
   <body>
+    <header>
+      <h1><%= link_to image_tag("logo.svg"), root_path %></h1>
+      <%= render(partial: "layouts/menu") %>
+      <%= render(partial: "layouts/google_login") %>
+    </header>
     <div class="wrapper">
-      <aside>
-        <h1><%= link_to image_tag("logo.svg"), root_path %></h1>
-        <%= render(partial: "layouts/menu") %>
-      </aside>
       <div class="main">
         <%= render(partial: "layouts/flash_messages") %>
         <%= yield %>
       </div>
     </div>
-    <%= render(partial: "layouts/google_login") %>
     <%= render(partial: "channels/form") %>
+    <footer>
+    <!-- 一時的に全ページのメニューを設置 -->
+    <ul>
+      <li><%= link_to("Channels", channels_path) %></li>
+      <li><%= link_to("Items", items_path) %></li>
+      <li><%= link_to("Pawprints", pawprints_path) %></li>
+      <li><%= link_to("Users", users_path) %></li>
+      <li><%= link_to("Inbox", inbox_path) %></li>
+      <li><%= link_to("Unreads", unreads_path) %></li>
+      <li><%= link_to("Settings", my_path) %></li>
+    </ul>
+
+    <p>© rururu</p>
+    </footer>
   </body>
 </html>


### PR DESCRIPTION
あまりの大改造で模索しながら進めたためコミットを分けることもできず、1コミットでめちゃくちゃ変えてしまいました…🫣

ざっくり変更内容は以下となりますっ

- サイドメニューを廃止
- 左下のログインボタン＆ログイン後のアイコン表示を廃止
- rururu ロゴ含め、ヘッダーにナビゲーションを集約
- ロゴと Channelサーチは左上、右上にその他を設置
- ログイン後は、右上にいくつかのメニューとアイコン（アイコンクリックでさらにメニュー表示）
- スマホ用にフッター下部にタブを設置
- 元々サイドバーにずらっと並べていた全ページへのリンクは、一旦開発者向け的にフッターに逃して配置（最終的には無くしたり必要はものは残したりしても良さそう。あと利用規約とか細かい静的ページを置くことも見越してのフッターエリア作成でした）