### PR TITLE
Slack 向け新着 Item 通知を実装する

### DIFF
--- a/app/jobs/item_creation_notifier_job.rb
+++ b/app/jobs/item_creation_notifier_job.rb
@@ -5,7 +5,7 @@ class ItemCreationNotifierJob < ApplicationJob
     return unless should_notify?(item)
 
     content = "New item saved"
-    embeds = [item.to_embed]
+    embeds = [item.to_discord_embed]
 
     DiscoPosterJob.perform_later(content:, embeds:)
   end

--- a/app/jobs/pawprint_creation_notifier_job.rb
+++ b/app/jobs/pawprint_creation_notifier_job.rb
@@ -4,7 +4,7 @@ class PawprintCreationNotifierJob < ApplicationJob
     user = pawprint.user
 
     content = "@#{user.name} pawed!"
-    embeds = [pawprint.to_embed]
+    embeds = [pawprint.to_discord_embed]
 
     DiscoPosterJob.perform_later(content:, embeds:)
   end

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -1,4 +1,6 @@
 class Channel < ApplicationRecord
+  include Rails.application.routes.url_helpers
+
   has_many :items, dependent: :destroy
   has_many :ownerships, dependent: :destroy
   has_many :owners, through: :ownerships, source: :user
@@ -152,5 +154,29 @@ class Channel < ApplicationRecord
 
   def image_url_or_placeholder
     image_url.presence || "https://placehold.jp/30/cccccc/ffffff/300x300.png?text=#{self.title}"
+  end
+
+  def to_slack_header_block
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "<%s|#{title}> 's recent items 📨" % [
+          Rails.application.credentials.google_auth_app.host + channel_path(self)
+        ]
+      }
+    }
+  end
+
+  def to_slack_more_block
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "Check out more recent items in <%s|#{title}>" % [
+          Rails.application.credentials.google_auth_app.host + channel_path(self)
+        ]
+      }
+   }
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -16,7 +16,7 @@ class Item < ApplicationRecord
     image_url.presence || "https://placehold.jp/30/cccccc/ffffff/270x180.png?text=#{self.title}"
   end
 
-  def to_embed
+  def to_discord_embed
     {
       author: { name: [channel.title, URI.parse(self.url).host].join(" | "), url: channel.site_url },
       title: self.title,

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -25,4 +25,19 @@ class Item < ApplicationRecord
       timestamp: self.published_at.iso8601,
     }
   end
+
+  def to_slack_block
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "<#{url}|#{title}>\n#{published_at.strftime("%Y-%m-%d %H:%M")}"
+      },
+      accessory: {
+        type: "image",
+        image_url: image_url,
+        alt_text: title,
+      }
+    }
+  end
 end

--- a/app/models/notification_webhook.rb
+++ b/app/models/notification_webhook.rb
@@ -22,14 +22,14 @@ class NotificationWebhook < ApplicationRecord
       if URI(url).host == "hooks.slack.com"
         notify_subscribed_items_to_slack
       else
-        notify_subscribed_items
+        notify_subscribed_items_to_discord
       end
     when "my_pawprints"
-      notify_pawprints
+      notify_pawprints_to_discord
     end
   end
 
-  def notify_pawprints(since: nil)
+  def notify_pawprints_to_discord(since: nil)
     at = since || last_notified_at || 6.hours.ago
     pawprints = user.pawprints.where("created_at >= ?", at).order(:id)
     return if pawprints.empty?
@@ -47,7 +47,7 @@ class NotificationWebhook < ApplicationRecord
     touch(:last_notified_at)
   end
 
-  def notify_subscribed_items(since: nil)
+  def notify_subscribed_items_to_discord(since: nil)
     at = since || last_notified_at || 6.hours.ago
     items = user.subscribed_items.where("items.created_at >= ?", at).order("items.id")
     return if items.empty?

--- a/app/models/notification_webhook.rb
+++ b/app/models/notification_webhook.rb
@@ -1,6 +1,4 @@
 class NotificationWebhook < ApplicationRecord
-  include Rails.application.routes.url_helpers
-
   belongs_to :user
 
   validates :user_id, presence: true
@@ -21,7 +19,7 @@ class NotificationWebhook < ApplicationRecord
   def notify
     case mode
     when "my_subscribed_items"
-      if URI(url).host == "hooks.slack.com" || url.ends_with?("/slack")
+      if URI(url).host == "hooks.slack.com"
         notify_subscribed_items_to_slack
       else
         notify_subscribed_items
@@ -85,43 +83,9 @@ class NotificationWebhook < ApplicationRecord
   end
 
   def build_blocks(channel, items)
-    items_blocks =
-      items.sort_by(&:id).reverse.take(4).map { |item|
-        {
-          type: "section",
-          text: {
-            type: "mrkdwn",
-            text: "<#{item.url}|#{item.title}>\n#{item.published_at.strftime("%Y-%m-%d %H:%M")}"
-          },
-          accessory: {
-            type: "image",
-            image_url: item.image_url,
-            alt_text: item.title,
-          }
-        }
-      }
+    items_blocks = items.sort_by(&:id).reverse.take(4).map(&:to_slack_block)
+    items_blocks.push(channel.to_slack_more_block) if items.size > 4
 
-    items_blocks.push(
-       {
-          type: "section",
-          text: {
-            type: "mrkdwn",
-            text: "Check out more recent items in <%s|#{channel.title}>" % [
-              Rails.application.credentials.google_auth_app.host + channel_path(channel)
-            ]
-          }
-       }
-    ) if items.size > 4
-
-    [
-      {
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: "<#{channel.site_url}|#{channel.title}> 's recent items 📨"
-        }
-      },
-      *items_blocks
-    ]
+    [channel.to_slack_header_block, *items_blocks]
   end
 end

--- a/app/models/notification_webhook.rb
+++ b/app/models/notification_webhook.rb
@@ -36,7 +36,7 @@ class NotificationWebhook < ApplicationRecord
 
     pawprints.to_a.each_slice(3).with_index { |sub_pawprints, index|
       content = "@#{user.name}'s recent pawprints 🐾" if index == 0
-      embeds = sub_pawprints.map(&:to_embed)
+      embeds = sub_pawprints.map(&:to_discord_embed)
 
       sleep 2
       Faraday.post(
@@ -54,7 +54,7 @@ class NotificationWebhook < ApplicationRecord
 
     items.to_a.each_slice(3).with_index { |sub_items, index|
       content = "Recent items in @#{user.name}'s subscribed channels 📨" if index == 0
-      embeds = sub_items.map(&:to_embed)
+      embeds = sub_items.map(&:to_discord_embed)
 
       sleep 2
       Faraday.post(

--- a/app/models/notification_webhook.rb
+++ b/app/models/notification_webhook.rb
@@ -1,4 +1,6 @@
 class NotificationWebhook < ApplicationRecord
+  include Rails.application.routes.url_helpers
+
   belongs_to :user
 
   validates :user_id, presence: true
@@ -19,7 +21,11 @@ class NotificationWebhook < ApplicationRecord
   def notify
     case mode
     when "my_subscribed_items"
-      notify_subscribed_items
+      if URI(url).host == "hooks.slack.com" || url.ends_with?("/slack")
+        notify_subscribed_items_to_slack
+      else
+        notify_subscribed_items
+      end
     when "my_pawprints"
       notify_pawprints
     end
@@ -59,5 +65,63 @@ class NotificationWebhook < ApplicationRecord
     }
 
     touch(:last_notified_at)
+  end
+
+  def notify_subscribed_items_to_slack(since: nil)
+    at = since || last_notified_at || 6.hours.ago
+    items = user.subscribed_items.preload(:channel).where("items.created_at >= ?", at)
+    return if items.empty?
+
+    items.group_by(&:channel).sort_by { |_, items| items.map(&:created_at).max }.each { |channel, sub_items|
+      blocks = build_blocks(channel, sub_items)
+
+      sleep 2
+      Faraday.post(
+        url, { blocks:, unfurl_links: false }.to_json, "Content-Type" => "application/json"
+      )
+    }
+
+    touch(:last_notified_at)
+  end
+
+  def build_blocks(channel, items)
+    items_blocks =
+      items.sort_by(&:id).reverse.take(4).map { |item|
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: "<#{item.url}|#{item.title}>\n#{item.published_at.strftime("%Y-%m-%d %H:%M")}"
+          },
+          accessory: {
+            type: "image",
+            image_url: item.image_url,
+            alt_text: item.title,
+          }
+        }
+      }
+
+    items_blocks.push(
+       {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: "Check out more recent items in <%s|#{channel.title}>" % [
+              Rails.application.credentials.google_auth_app.host + channel_path(channel)
+            ]
+          }
+       }
+    ) if items.size > 4
+
+    [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: "<#{channel.site_url}|#{channel.title}> 's recent items 📨"
+        }
+      },
+      *items_blocks
+    ]
   end
 end

--- a/app/models/pawprint.rb
+++ b/app/models/pawprint.rb
@@ -8,7 +8,7 @@ class Pawprint < ApplicationRecord
 
   after_create_commit { PawprintCreationNotifierJob.perform_later(self.id) }
 
-  def to_embed
+  def to_discord_embed
     channel = item.channel
     {
       author: { name: [channel.title, URI.parse(item.url).host].join(" | "), url: channel.site_url },


### PR DESCRIPTION
既存の Discord 向け新着 Item 通知との違いは、下記の通り :dash:

- Discord の embeds の代わりに Slack の blocks にあわせて JSON を組み立てる
- Item ひとつずつではなく、Channel ごとに Item をグルーピングして処理する
