### PR TITLE
スタイリング @ 2024-04-19

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -31,7 +31,7 @@ h1 {
 
 @media screen and (max-width: 768px) {
   h1 {
-    margin: 0.25em 0 0;
+    margin: 0;
   }
 }
 
@@ -923,7 +923,7 @@ img {
 @media screen and (max-width: 768px) {
   .channel_search {
     width: calc(100% - 66px);
-    margin: 8px 10px 0 20px;
+    margin: 3px 10px 0 20px;
   }
 }
 

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -71,7 +71,9 @@ a:hover {
 
 @media screen and (max-width: 768px) {
   .google-login {
-    bottom: 60px;
+    position: fixed;
+    top: auto;
+    bottom: 80px;
     box-shadow: 0px 0px 8px -4px #555555;
   }
 }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1022,6 +1022,23 @@ img {
   opacity: 0.5;
 }
 
+.unreads-list {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  border-top: 0.5px solid #dddddd;
+}
+
+.unreads-list a {
+  width: 50%;
+  border-top: none !important;
+}
+
+@media screen and (max-width: 768px) {
+  .unreads-list a {
+    width: 100%;
+  }
+}
 
 .channel-and-items-component-item-image {
   width: 96px;
@@ -1038,7 +1055,7 @@ img {
   .channel-and-items-component-item-image {
     width: 96px;
     height: 64px;
-    margin: 0 10px 8px 0;
+    margin: 0 10px 0 0;
   }
 }
 
@@ -1055,7 +1072,7 @@ img {
 }
 
 .channel-and-items-component-item-info-unreads {
-  width: calc(50% - 126px);
+  width: calc(100% - 126px);
   margin: 0 20px 0 0;
 }
 
@@ -1069,12 +1086,12 @@ img {
 .channel-and-items-component-item-paw {
   display: flex;
   width: 50%;
-  margin: 10px 0 0;
 }
 
 @media screen and (max-width: 768px) {
   .channel-and-items-component-item-paw {
     width: 100%;
+    margin: -0.5em 0 1em;
   }
 }
 
@@ -1086,9 +1103,9 @@ img {
 }
 
 .channel-and-items-component-item-skip a {
-  display: inline-block;
+  display: inline-block !important;
   width: 50px;
-  padding: 6px 0px;
+  padding: 6px 0px !important;
   text-align: center;
   background-color: #999999;
   color: #ffffff;
@@ -1108,6 +1125,11 @@ img {
 .channel-and-items-component-item-memo p {
   background-color: #ffffff;
   padding: 0.75em 1em;
+}
+
+.channel-and-items-component-item-more {
+  padding: 0.75em 0;
+  border-top: 0.5px solid #dddddd;
 }
 
 footer {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -63,8 +63,8 @@ a:hover {
 
 .google-login {
   position: absolute;
-  top: 10px;
-  right: 10px;
+  top: 18px;
+  right: 15px;
   padding: 0;
   z-index: 1;
 }
@@ -242,8 +242,9 @@ header {
 }
 
 header h1 {
-  width: 144px;
   display: flex;
+  width: 144px;
+  height: 72px;
   align-items: center;
 
   img {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -957,11 +957,12 @@ img {
   }
 }
 
-.channel-and-items-component-channel {
+.channel-and-items-component-channel a {
   display: flex;
   flex-wrap: wrap;
   justify-content: left;
   align-items: center;
+  height: 64px;
 
   img {
     width: 64px;
@@ -977,11 +978,23 @@ img {
   }
 }
 
+.channel-and-items-component-channel a:hover {
+  text-decoration: none;
+}
+
+.channel-and-items-component-channel a img {
+  transition: 0.5s;
+}
+
+.channel-and-items-component-channel a:hover img {
+  opacity: 0.5;
+}
+
 .channel-and-items-component-item-list {
   margin: 1em 0 0.5em;
 }
 
-.channel-and-items-component-item-list li {
+.channel-and-items-component-item-list li a {
   position: relative;
   display: flex;
   flex-wrap: wrap;
@@ -992,10 +1005,23 @@ img {
 }
 
 @media screen and (max-width: 768px) {
-  .channel-and-items-component-item-list li {
+  .channel-and-items-component-item-list li a {
     padding: 1em 0em;
   }
 }
+
+.channel-and-items-component-item-list li a:hover {
+  text-decoration: none;
+}
+
+.channel-and-items-component-item-list li a img {
+  transition: 0.5s;
+}
+
+.channel-and-items-component-item-list li a:hover img {
+  opacity: 0.5;
+}
+
 
 .channel-and-items-component-item-image {
   width: 96px;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -289,7 +289,7 @@ header nav ul li a {
   display: flex;
   align-items: center;
   margin: 0;
-  padding: 0.5em;
+  padding: 0.75em;
 }
 
 header nav ul li a:hover {
@@ -299,19 +299,6 @@ header nav ul li a:hover {
 
 .material-symbols-outlined {
   margin: 0 0.2em 0 0;
-}
-
-@media screen and (max-width: 768px) {
-  .material-symbols-outlined {
-    margin: 0;
-    padding: 6px 0 0;
-    font-size: 32px;
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-  }
 }
 
 .material-symbols-outlined-search {
@@ -361,7 +348,7 @@ header nav ul li a:hover {
 
 .hamburger-menu-list li {
   width: 100%;
-  padding: 5px;
+  padding: 0;
   border-bottom: solid 1px #cccccc;
 }
 
@@ -489,6 +476,17 @@ header nav ul li a:hover {
     padding: 36px 0 0;
     font-size: 10px;
     color: #ffffff;
+  }
+
+  .material-symbols-outlined-sp-tab {
+    margin: 0;
+    padding: 6px 0 0;
+    font-size: 32px;
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
   }
 }
 

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -831,6 +831,9 @@ img {
 }
 
 .setting-card .card-image {
+  display: flex;
+  justify-content: center;
+  align-items: center;
   background-color: #ffffff;
 }
 
@@ -840,9 +843,19 @@ img {
   }
 }
 
+.setting-card .card-image .material-symbols-outlined {
+  margin: 0;
+  font-size: 96px;
+  color: #ccc;
+}
+
+.setting-card a {
+  transition: 0.5s;
+}
+
 .setting-card a:hover {
   text-decoration: none;
-  opacity: 0.8;
+  opacity: 0.7;
 }
 
 .nav-setting {

--- a/app/views/layouts/_menu.html.erb
+++ b/app/views/layouts/_menu.html.erb
@@ -49,20 +49,20 @@
   <ul>
     <li>
       <%= link_to(root_path) do %>
-        <span class="material-symbols-outlined">home</span>
+        <span class="material-symbols-outlined material-symbols-outlined-sp-tab">home</span>
         <span>Home</span>
       <% end %>
     </li>
     <% if logged_in? %>
     <li>
       <%= link_to(unreads_path) do %>
-        <span class="material-symbols-outlined">inbox</span>
+        <span class="material-symbols-outlined material-symbols-outlined-sp-tab">inbox</span>
         <span>Unreads</span>
       <% end %>
     </li>
     <li>
       <%= link_to(my_path) do %>
-        <span class="material-symbols-outlined">settings</span>
+        <span class="material-symbols-outlined material-symbols-outlined-sp-tab">settings</span>
         <span>Settings</span>
       <% end %>
     </li>

--- a/app/views/my/index.html.erb
+++ b/app/views/my/index.html.erb
@@ -4,18 +4,22 @@
 <div class="cards">
 
   <div class="card item-card setting-card">
-    <div class="card-image">
-      <%= link_to("", my_profile_path, class: 'nav-icon nav-setting nav-icon-profile-setting') %>
-    </div>
-    <h3 class="card-title"><%= link_to("My Profile", my_profile_path) %></h3>
+    <%= link_to(my_profile_path) do %>
+      <div class="card-image">
+        <span class="material-symbols-outlined">badge</span>
+      </div>
+      <h3 class="card-title">My Profile</h3>
+    <% end %>
   </div>
   <div class="card item-card setting-card">
-    <div class="card-image">
-      <%= link_to("", my_notification_webhooks_path, class: 'nav-icon nav-setting nav-icon-webhook-setting') %>
-    </div>
-    <h3 class="card-title"><%= link_to("My Notification Webhooks", my_notification_webhooks_path) %></h3>
+    <%= link_to(my_notification_webhooks_path) do %>
+      <div class="card-image">
+        <span class="material-symbols-outlined">webhook</span>
+      </div>
+      <h3 class="card-title">My Notification Webhooks</h3>
+    <% end %>
   </div>
 
-  </div>
+</div>
 
 </section>

--- a/app/views/my/unreads/show.html.erb
+++ b/app/views/my/unreads/show.html.erb
@@ -7,39 +7,43 @@
 <% @channel_and_items.each do |channel, items| %>
   <div class="channel-and-items-component channel-and-items-component-unreads">
     <h3 class="channel-and-items-component-channel">
-      <% if channel.image_url %>
-      <%= image_tag(channel.image_url, size: "64x64",) %>
+      <%= link_to channel_path(channel) do %>
+        <% if channel.image_url %>
+        <%= image_tag(channel.image_url, size: "64x64",) %>
+        <% end %>
+        <span>
+          <%= channel.title %>
+        </span>
       <% end %>
-      <span>
-        <%= link_to(channel.title, channel) %>
-      </span>
     </h3>
     <ul class="channel-and-items-component-item-list">
       <% items.sort_by(&:published_at).reverse.take(6).each do |item| %>
         <%= turbo_frame_tag(item) do %>
-        <li>
-          <div class="channel-and-items-component-item-image">
-            <%= image_tag(item.image_url_or_placeholder, width: "100%", height: "100%", style: "object-fit: cover;") %>
+        <li class="unreads-list">
+          <%= link_to(item.url, target: "_blank") do %>
+            <div class="channel-and-items-component-item-image">
+              <%= image_tag(item.image_url_or_placeholder, width: "100%", height: "100%", style: "object-fit: cover;") %>
+            </div>
+            <div class="channel-and-items-component-item-info channel-and-items-component-item-info-unreads">
+              <h4>
+                <%= item.title %>
+              </h4>
+              <%= item.published_at.strftime("%Y-%m-%d %H:%M") %>
+            </div>
+          <% end %>
+          <div class="channel-and-items-component-item-paw">
+            <div class="channel-and-items-component-item-skip">
+              <%= link_to("Skip", item_skip_path(item), data: { turbo_method: :post }) %>
+            </div>
+            <div class="channel-and-items-component-item-memo">
+              <%= render(partial: "items/pawprint_form", locals: { item: item, pawprint: nil }) %>
+            </div>
           </div>
-        <div class="channel-and-items-component-item-info channel-and-items-component-item-info-unreads">
-          <h4>
-          <%= link_to(item.title, item.url, target: "_blank") %>
-          </h4>
-          <%= item.published_at.strftime("%Y-%m-%d %H:%M") %>
-        </div>
-        <div class="channel-and-items-component-item-paw">
-          <div class="channel-and-items-component-item-skip">
-            <%= link_to("Skip", item_skip_path(item), data: { turbo_method: :post }) %>
-          </div>
-          <div class="channel-and-items-component-item-memo">
-            <%= render(partial: "items/pawprint_form", locals: { item: item, pawprint: nil }) %>
-          </div>
-        </div>
         </li>
         <% end %>
       <% end %>
       <% if items.size > 6 %>
-        <p>
+        <p class="channel-and-items-component-item-more">
           Check out more unreads on <%= link_to(channel.title, channel) %>
         </p>
       <% end %>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -2,26 +2,30 @@
 <% @channels.each do |channel| %>
   <div class="channel-and-items-component">
     <h3 class="channel-and-items-component-channel">
-      <% if channel.image_url %>
-      <%= image_tag(channel.image_url, size: "64x64",) %>
+      <%= link_to channel_path(channel) do %>
+        <% if channel.image_url %>
+        <%= image_tag(channel.image_url, size: "64x64",) %>
+        <% end %>
+        <span>
+          <%= channel.title %>
+        </span>
       <% end %>
-      <span>
-        <%= link_to(channel.title, channel) %>
-      </span>
     </h3>
     <ul class="channel-and-items-component-item-list">
       <% channel.items.order(id: :desc).limit(3).each do |item| %>
         <%= turbo_frame_tag(item) do %>
         <li>
+        <%= link_to(item.url, target: "_blank") do %>
           <div class="channel-and-items-component-item-image">
             <%= image_tag(item.image_url_or_placeholder, width: "100%", height: "100%", style: "object-fit: cover;") %>
           </div>
-        <div class="channel-and-items-component-item-info">
-          <h4>
-          <%= link_to(item.title, item.url, target: "_blank") %>
-          </h4>
-          <%= item.published_at.strftime("%Y-%m-%d %H:%M") %>
-        </div>
+          <div class="channel-and-items-component-item-info">
+            <h4>
+              <%= item.title %>
+            </h4>
+            <%= item.published_at.strftime("%Y-%m-%d %H:%M") %>
+          </div>
+        <% end %>
         </li>
         <% end %>
       <% end %>


### PR DESCRIPTION
引き続き気になるところのスタイリング🚀

- 前回、アイコンを細いバージョンに変えたに伴う不具合がいくつかあったので修正
  - スマホでのマイメニュー（My Pawprintsなど）のアイコンが崩れてたので修正
  - Settingページのアイコン（My Profileなど）が消滅してたので蘇生
- 前回MTGで出た、トップやUnreadsページでのリンク領域を広げてクリック（タップ）しやすくした
- その他細かいスタイルの調整