### PR TITLE
Channels::FetchController、運営通知を入れて末尾の空行を削除する

### DIFF
--- a/app/controllers/channels/fetch_controller.rb
+++ b/app/controllers/channels/fetch_controller.rb
@@ -5,8 +5,8 @@ class Channels::FetchController < ApplicationController
     channel = Channel.find(params[:channel_id])
     Channel.add(channel.feed_url)
     ChannelItemsUpdaterJob.perform_later(channel_id: channel.id)
+    DiscoPosterJob.perform_later(content: "@#{current_user.name} requested to update #{channel.title}")
 
     redirect_to channel, notice: "Channel updated, and fetching items in the background."
   end
 end
-


### PR DESCRIPTION
- 運営向けの Discord 通知処理を入れる
- 末尾の空行が 2 行あったので削る
