### PR TITLE
先頭や末尾に空白文字が入っちゃうケースがあるので、データベースに保存する前に strip する

### DIFF
--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -1,5 +1,6 @@
 class Channel < ApplicationRecord
   include Rails.application.routes.url_helpers
+  include Stripable
 
   has_many :items, dependent: :destroy
   has_many :ownerships, dependent: :destroy
@@ -14,6 +15,7 @@ class Channel < ApplicationRecord
   validates :feed_url, presence: true, length: { maximum: 2083 }, uniqueness: true
   validates :image_url, length: { maximum: 2083 }
 
+  strip_before_save :title, :description
   after_create_commit { ChannelItemsUpdaterJob.perform_later(channel_id: self.id, mode: :all) }
 
   scope :not_stopped, -> { where.missing(:stopper) }

--- a/app/models/concerns/stripable.rb
+++ b/app/models/concerns/stripable.rb
@@ -1,0 +1,20 @@
+module Stripable
+  extend ActiveSupport::Concern
+
+  included do
+    class_attribute :stripable_columns
+    before_save :strip_columns
+  end
+
+  class_methods do
+    def strip_before_save(*columns)
+      self.stripable_columns = columns
+    end
+  end
+
+  def strip_columns
+    self.stripable_columns.each do |column|
+      self.send("#{column}=", self.send(column).strip) if self.send(column).respond_to?(:strip)
+    end
+  end
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,4 +1,6 @@
 class Item < ApplicationRecord
+  include Stripable
+
   belongs_to :channel
   has_many :pawprints, dependent: :destroy
   has_many :pawed_users, through: :pawprints, source: :user
@@ -10,6 +12,7 @@ class Item < ApplicationRecord
   validates :image_url, length: { maximum: 2083 }
   validates :published_at, presence: true
 
+  strip_before_save :title
   after_create_commit { ItemCreationNotifierJob.perform_later(self.id) }
 
   def image_url_or_placeholder


### PR DESCRIPTION
### 経緯

新着 Item の Slack 通知を見ていたら、表示が意図した通りになっていないものを見つけた。なんぞ？

![feed__Channel__-_june29_-_Slack](https://github.com/kairan-app/feeeed/assets/125535885/08edbcca-2022-4b22-b4c2-ae40c4bc45fd)

### 原因

見ていたら、The HEADLINE の Channel と Item の文字列カラムには、先頭・末尾に空白文字が入ってしまっているっぽかった。なるほどね〜〜。

```
#<Channel:0x00007f57ece336e0
 id: 199,
 title: "The HEADLINE",
 description: "\n      The HEADLINE RSS\n    ",
 site_url: "https://www.theheadline.jp",
 feed_url: "https://www.theheadline.jp/rss/feeds.xml",
 image_url: "https://d2bz98p2lfzf5b.cloudfront.net/GbHwg5yhkd3d78ds5vXtrfML",
 created_at: Mon, 18 Mar 2024 17:59:06.059555000 JST +09:00,
 updated_at: Mon, 18 Mar 2024 17:59:06.059555000 JST +09:00>

#<Item:0x00007f57ecc99af0
 id: 24255,
 channel_id: 199,
 guid: "https://www.theheadline.jp/articles/1060",
 title: "\n        Meta の詐欺広告問題、日本は「なめられている」のか？前澤氏・堀江氏ら批判\n      ",
 url: "https://www.theheadline.jp/articles/1060",
 image_url: "https://d2bz98p2lfzf5b.cloudfront.net/UHTchrrWV2FggveS3ck9Pv8a",
 published_at: Wed, 24 Apr 2024 20:35:46.000000000 JST +09:00,
 created_at: Wed, 24 Apr 2024 21:11:14.886887000 JST +09:00,
 updated_at: Wed, 24 Apr 2024 21:11:14.886887000 JST +09:00>
```

### 対策

- Channel の title と description
- Item の title

については、データベースに値を保存する前に String#strip で空白文字を削っちゃうことにする。