### PR TITLE
docker-compose.yml の version はもう書かなくていいみたい

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   web:
     build: .


### PR DESCRIPTION
`docker-compose up` したときに

```
WARN[0000] /path/to/ghq/src/github.com/kairan-app/feeeed/docker-compose.yml: `version` is obsolete
```

と表示されると気が付いた。調べてみると version は単純に書かなきゃいいってことなので、消します！

https://docs.docker.com/compose/compose-file/04-version-and-name/
