### PR TITLE
Channel や Item の保存失敗時に運営 Discord に通知する

### DIFF
--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -1,6 +1,7 @@
 class Channel < ApplicationRecord
   include Rails.application.routes.url_helpers
   include Stripable
+  include ValidationErrorsNotifiable
 
   has_many :items, dependent: :destroy
   has_many :ownerships, dependent: :destroy
@@ -16,6 +17,7 @@ class Channel < ApplicationRecord
   validates :image_url, length: { maximum: 2083 }
 
   strip_before_save :title, :description
+  after_validation :notify_validation_errors
   after_create_commit { ChannelItemsUpdaterJob.perform_later(channel_id: self.id, mode: :all) }
 
   scope :not_stopped, -> { where.missing(:stopper) }

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -135,16 +135,7 @@ class Channel < ApplicationRecord
         image_url: image_url,
         published_at: entry.published,
       }
-      item = self.items.find_or_initialize_by(guid: guid)
-      successed = item.update(parameters)
-
-      unless successed
-        content = [
-          "Channel id:#{self.id}, item save failed: #{item.errors.full_messages.join(", ")}",
-          "```", parameters.to_yaml, "```",
-        ].join("\n")
-        DiscoPosterJob.perform_later(content: content)
-      end
+      self.items.find_or_initialize_by(guid: guid).update(parameters)
     end
   end
 

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -17,7 +17,6 @@ class Channel < ApplicationRecord
   validates :image_url, length: { maximum: 2083 }
 
   strip_before_save :title, :description
-  after_validation :notify_validation_errors
   after_create_commit { ChannelItemsUpdaterJob.perform_later(channel_id: self.id, mode: :all) }
 
   scope :not_stopped, -> { where.missing(:stopper) }

--- a/app/models/concerns/validation_errors_notifiable.rb
+++ b/app/models/concerns/validation_errors_notifiable.rb
@@ -1,4 +1,10 @@
 module ValidationErrorsNotifiable
+  extend ActiveSupport::Concern
+
+  included do
+    after_validation :notify_validation_errors
+  end
+
   def notify_validation_errors
     return if errors.empty?
 

--- a/app/models/concerns/validation_errors_notifiable.rb
+++ b/app/models/concerns/validation_errors_notifiable.rb
@@ -1,0 +1,11 @@
+module ValidationErrorsNotifiable
+  def notify_validation_errors
+    return if errors.empty?
+
+    content = [
+      "#{self.class} save failed: #{errors.full_messages.join(", ")}",
+      "```#{attributes.to_yaml}```",
+    ].join("\n")
+    DiscoPosterJob.perform_later(content: content)
+  end
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -14,7 +14,6 @@ class Item < ApplicationRecord
   validates :published_at, presence: true
 
   strip_before_save :title
-  after_validation :notify_validation_errors
   after_create_commit { ItemCreationNotifierJob.perform_later(self.id) }
 
   def image_url_or_placeholder

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,6 @@
 class Item < ApplicationRecord
   include Stripable
+  include ValidationErrorsNotifiable
 
   belongs_to :channel
   has_many :pawprints, dependent: :destroy
@@ -43,15 +44,5 @@ class Item < ApplicationRecord
         alt_text: title,
       }
     }
-  end
-
-  def notify_validation_errors
-    return if errors.empty?
-
-    content = [
-      "#{self.class} save failed: #{errors.full_messages.join(", ")}",
-      "```#{attributes.to_yaml}```",
-    ].join("\n")
-    DiscoPosterJob.perform_later(content: content)
   end
 end


### PR DESCRIPTION
@sugiwe さんの 2024-05-02 の日記が、Validation に引っかかって Item として保存できていないことに気付きました :sob:

制約を見直して保存できるようにする対応はこのあとすぐにやるのですが、その前に、事象に気付けていない体制がまずい (これまで、他にも保存できていないものがあったと想像される) ので、通知を実装しておきます :pray:
