### PR TITLE
Item の guid には URL を入れるケースがあるので、長さ 2083 まで許容したい

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -7,7 +7,7 @@ class Item < ApplicationRecord
   has_many :pawed_users, through: :pawprints, source: :user
 
   validates :channel_id, presence: true
-  validates :guid, presence: true, length: { maximum: 256 }, uniqueness: { scope: :channel_id }
+  validates :guid, presence: true, length: { maximum: 2083 }, uniqueness: { scope: :channel_id }
   validates :title, presence: true, length: { maximum: 256 }
   validates :url, presence: true, length: { maximum: 2083 }
   validates :image_url, length: { maximum: 2083 }

--- a/db/migrate/20240503013247_make_items_guid_longer.rb
+++ b/db/migrate/20240503013247_make_items_guid_longer.rb
@@ -1,0 +1,5 @@
+class MakeItemsGuidLonger < ActiveRecord::Migration[7.1]
+  def change
+    change_column :items, :guid, :string, limit: 2083
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_25_143230) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_03_013247) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -46,7 +46,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_25_143230) do
 
   create_table "items", force: :cascade do |t|
     t.bigint "channel_id", null: false
-    t.string "guid", limit: 256, null: false
+    t.string "guid", limit: 2083, null: false
     t.string "title", limit: 256, null: false
     t.string "url", limit: 2083, null: false
     t.string "image_url", limit: 2083


### PR DESCRIPTION
掲題の通りで、むしろ「なんで最初からそうしていなかったの？？？」という @juneboku の凡ミス :sob:

実際に guid が長くなる Item の保存に失敗していると @sugiwe さんが気付いてくれたおかげで修正につながりました :pray:
