### PR TITLE
フィードの中の title が設定されていない entry は無視する

### DIFF
--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -116,6 +116,7 @@ class Channel < ApplicationRecord
       sleep 2
 
       p ["Fetching", entry.published, entry.title, entry.url]
+      next if entry.title.blank?
 
       url = entry.url || self.site_url
       encoded_url = url.chars.map { |c| c.bytesize > 1 ? URI.encode_www_form_component(c) : c }.join


### PR DESCRIPTION
- https://github.com/kairan-app/feeeed/pull/171

によって通知を入れたことで、Item を保存しようとして title がなくて Validation に引っかかるケースがちょこちょこあることが判明した。そうだったのか〜。

https://validator.w3.org/feed/ にて title なしの entry を持つようなフィードを検証してみると、title がないと Invalid という判定になった。仕様では entry に title を要求しているんですね。

であれば、rururu は「迷ったら仕様に従う」として、title がないものは無視しますよ、というスタンスで進めてみようと思います。もちろん、title 以外の情報から適当に title っぽい文字列を決めてあげれば保存はできるわけですが、それは Invalid なフィードの存在をイネーブリングすることにはなるので、望ましい対応ではないと考えました。

議論の余地はあると思うので、別の意見があればぜひコメントください！ :wink:
