### PR TITLE
モデルにおいて、空文字ならnilにして保存してほしいカラムを指定しておく

### DIFF
--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -1,6 +1,7 @@
 class Channel < ApplicationRecord
   include Rails.application.routes.url_helpers
   include Stripable
+  include EmptyStringsAreAlignedToNil
   include ValidationErrorsNotifiable
 
   has_many :items, dependent: :destroy
@@ -17,6 +18,7 @@ class Channel < ApplicationRecord
   validates :image_url, length: { maximum: 2083 }
 
   strip_before_save :title, :description
+  empty_strings_are_aligned_to_nil :description, :site_url, :image_url
   after_create_commit { ChannelItemsUpdaterJob.perform_later(channel_id: self.id, mode: :all) }
 
   scope :not_stopped, -> { where.missing(:stopper) }

--- a/app/models/concerns/empty_strings_are_aligned_to_nil.rb
+++ b/app/models/concerns/empty_strings_are_aligned_to_nil.rb
@@ -1,0 +1,20 @@
+module EmptyStringsAreAlignedToNil
+  extend ActiveSupport::Concern
+
+  included do
+    class_attribute :empty_strings_are_aligned_to_nil_columns
+    before_validation :align_empty_strings_to_nil
+  end
+
+  class_methods do
+    def empty_strings_are_aligned_to_nil(*columns)
+      self.empty_strings_are_aligned_to_nil_columns = columns
+    end
+  end
+
+  def align_empty_strings_to_nil
+    empty_strings_are_aligned_to_nil_columns.each do |column|
+      self[column] = nil if self[column].blank?
+    end
+  end
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,6 @@
 class Item < ApplicationRecord
   include Stripable
+  include EmptyStringsAreAlignedToNil
   include ValidationErrorsNotifiable
 
   belongs_to :channel
@@ -14,6 +15,7 @@ class Item < ApplicationRecord
   validates :published_at, presence: true
 
   strip_before_save :title
+  empty_strings_are_aligned_to_nil :image_url
   after_create_commit { ItemCreationNotifierJob.perform_later(self.id) }
 
   def image_url_or_placeholder


### PR DESCRIPTION
### 経緯

Channel の image_url が nil なら img タグを出力しないはずだけれど、これはなんじゃろう？と思って。

![テノニッキ_-_rururu_-_Vivaldi](https://github.com/kairan-app/feeeed/assets/125535885/3a76e0c7-85db-466a-9782-c8c47c12fdfe)

データを見てみたら image_url が nil ではなくて空文字列であった。うーむ、なるほどね！

これはウェブアプリケーションを開発・運用している全員の悩みという気もするな… すでにベスト・プラクティスが存在しそうなトピックではあるけれど、自前で「こんな感じかな…？」という手を打ってみます。もっといい方法が見つかったらすぐに乗り換えるぜ :muscle:

### 現状確認

```rb
> Channel.where(description: "").count
=> 0
> Channel.where(description: nil).count
=> 37

> Channel.where(image_url: "").count
=> 1
> Channel.where(image_url: nil).count
=> 35

> Channel.where(site_url: "").count
=> 0
> Channel.where(site_url: nil).count
=> 1
```
