### PR TITLE
アルファ・リリースに向けて、なにも知らん人が見にきたときのナビゲーションを整えておく

### DIFF
--- a/app/controllers/channels_controller.rb
+++ b/app/controllers/channels_controller.rb
@@ -4,7 +4,7 @@ class ChannelsController < ApplicationController
   def index
     @q = Channel.ransack(params[:q])
     page = (params[:page].presence || 1).to_i
-    @channels = @q.result.order(updated_at: :desc).page(page)
+    @channels = @q.result.order(updated_at: :desc).page(page).per(60)
 
     @title = page == 1 ? "Channels" : "Channels (Page #{page})"
   end

--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -1,0 +1,5 @@
+class InfoController < ApplicationController
+  def index
+    @title = "Info"
+  end
+end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   def index
     page = (params[:page].presence || 1).to_i
-    @items = Item.preload(:pawprints).eager_load(:channel).order(published_at: :desc, title: :desc).page(page)
+    @items = Item.preload(:pawprints).eager_load(:channel).order(published_at: :desc, title: :desc).page(page).per(48)
 
     @title = page == 1 ? "Items" : "Items (Page #{page})"
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -10,15 +10,16 @@ class SessionsController < ApplicationController
       aud: Rails.application.credentials.google_auth_app.client_id
     )
     email = payload["email"]
+    local_part = email.split("@").first
 
-    unless ENV["ALLOWED_EMAILS"].split(",").include?(email)
+    unless ENV["ALLOWED_USERS"].split(",").include?(local_part)
       DiscoPosterJob.perform_later(content: "#{email} tried to log in")
       return redirect_to root_path
     end
 
     user = User.find_or_initialize_by(google_guid: payload["sub"])
     user.email ||= email
-    user.name ||= email.split("@").first
+    user.name ||= local_part
     user.icon_url = payload["picture"]
     user.save
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -14,7 +14,7 @@ class SessionsController < ApplicationController
 
     unless ENV["ALLOWED_USERS"].split(",").include?(local_part)
       DiscoPosterJob.perform_later(content: "#{email} tried to log in")
-      return redirect_to root_path
+      return redirect_to info_path
     end
 
     user = User.find_or_initialize_by(google_guid: payload["sub"])

--- a/app/views/info/index.html.erb
+++ b/app/views/info/index.html.erb
@@ -1,0 +1,18 @@
+<%= render(partial: "layouts/hero", locals: { show_buttons: false }) %>
+<div class="about-contents">
+  <h2>Info</h2>
+  <section>
+    <h2>
+      現在、アルファ・テスト期間です。
+    </h2>
+    <p>
+      このページに訪れていただき、ありがとうございます。<br>
+      正式リリースを目指して開発を進めているrururuは、現在、特定少数の利用者に限定してアルファ・テストを行っています。<br>
+      そのため新規の利用登録を受け付けておりません。<br>
+      もし、rururuに興味を持っていただけましたら、開発チームのjunebokuかsugiweにお声がけください。<br>
+      アルファ・テストの次にベータ・テストを実施することになれば、その際に連絡させていただきます。<br>
+      <br>
+      2024年5月8日
+    </p>
+  </section>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,6 +53,8 @@ Rails.application.routes.draw do
   get    "/my/notification_settings",          to: "my/notification_settings#index"
   get    "/about",                             to: "about#index",
                                                as: "about"
+  get    "/info",                              to: "info#index",
+                                               as: "info"
 
   root "welcome#index"
 end


### PR DESCRIPTION
- 許可リストに登録されていない人がログインしようとしたら、Info ページにリダイレクトする
- Info ページには「アルファ・テスト中で、利用登録は受け付けていないよ」を説明する
- Channel 一覧 / Item 一覧のページ当たりの表示件数は、なるべく約数の多い数にしておいて見栄えを少しよくする
