### PR TITLE
Unreads ページの対象抽出さかのぼり日数を session に保存する

### DIFF
--- a/app/controllers/my/unreads_controller.rb
+++ b/app/controllers/my/unreads_controller.rb
@@ -1,12 +1,14 @@
 class My::UnreadsController < MyController
   def show
-    @days_before = (params[:days_before].presence || 3).to_i
+    @range_days = (params[:range_days].presence || session[:range_days] || 3).to_i
+    session[:range_days] = @range_days
+
     @channel_and_items =
       current_user.subscribed_items.
       preload(:channel).
       where("NOT EXISTS (SELECT 1 FROM pawprints WHERE pawprints.item_id = items.id AND pawprints.user_id = ?)", current_user.id).
       where("NOT EXISTS (SELECT 1 FROM item_skips WHERE item_skips.item_id = items.id AND item_skips.user_id = ?)", current_user.id).
-      where("items.created_at > ?", @days_before.days.ago).
+      where("items.created_at > ?", @range_days.days.ago).
       group_by(&:channel).
       sort_by { |_, items| items.map(&:created_at).max }.
       reverse

--- a/app/views/my/unreads/show.html.erb
+++ b/app/views/my/unreads/show.html.erb
@@ -1,8 +1,8 @@
 <h2>Unreads</h2>
-<p class="unreads-nav">Showing unreads from the last <%= @days_before %> days</p>
+<p class="unreads-nav">Showing unreads from the last <%= @range_days %> days</p>
 <div class="unreads-nav-button">
-  <%= link_to("← " + (@days_before - 1).to_s + " days", unreads_path(days_before: @days_before - 1)) %>
-  <%= link_to((@days_before + 1).to_s + " days →", unreads_path(days_before: @days_before + 1)) %>
+  <%= link_to("← " + (@range_days - 1).to_s + " days", unreads_path(range_days: @range_days - 1)) %>
+  <%= link_to((@range_days + 1).to_s + " days →", unreads_path(range_days: @range_days + 1)) %>
 </div>
 <% @channel_and_items.each do |channel, items| %>
   <div class="channel-and-items-component channel-and-items-component-unreads">


### PR DESCRIPTION
今は params で指定しないとデフォルトの 3 になっちゃっていたんだけど、session に保存するようにして、各利用者にとってのちょうどいい日数を見つけてもらいやすくなるといいな〜の気持ちです :v:
