### PR TITLE
User#name は 30 文字までオッケーとする

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ApplicationRecord
   has_many :notification_webhooks, dependent: :destroy
   has_many :notification_emails, dependent: :destroy
 
-  validates :name, presence: true, uniqueness: true, length: { in: 2..15 }
+  validates :name, presence: true, uniqueness: true, length: { in: 2..30 }
   validates :email, presence: true, length: { maximum: 254 }
   validates :icon_url, presence: true, length: { maximum: 2083 }
 

--- a/db/migrate/20240510075930_make_users_name_longer.rb
+++ b/db/migrate/20240510075930_make_users_name_longer.rb
@@ -1,0 +1,5 @@
+class MakeUsersNameLonger < ActiveRecord::Migration[7.1]
+  def change
+    change_column :users, :name, :string, limit: 30
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_03_013247) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_10_075930) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -112,7 +112,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_03_013247) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "name", limit: 15, null: false
+    t.string "name", limit: 30, null: false
     t.string "email", limit: 254, null: false
     t.string "icon_url", limit: 2083, null: false
     t.datetime "created_at", null: false


### PR DESCRIPTION
開発の初期になんとなく 2 〜 15 文字という制約を設定していたが、これだと Gmail のローカルパートが 16 文字以上の人は Signup 失敗してします :innocent:

当面は Google ログインでいくので、

> ユーザー名は 6～30 文字で指定してください。
> [ユーザー名の作成 \- Gmail ヘルプ](https://support.google.com/mail/answer/9211434?hl=ja)

に従って 30 文字まで許容します :v:
