### PR TITLE
Pawprintsページのプチ改善

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -716,8 +716,8 @@ img {
 .pawprint-list li {
   display: flex;
   flex-wrap: wrap;
-  margin: 0 20px 0.5em 0;
-  padding: 0.5em 0;
+  margin: 0 20px 0 0;
+  padding: 0.75em 0;
   border-top: 1px solid #aaaaaa;
   line-height: 1.5em;
 }
@@ -739,6 +739,8 @@ img {
 }
 
 .pawprint-info {
+  display: flex;
+  flex-wrap: wrap;
   width: 50%;
   margin: 0 20px 0 0;
 }
@@ -750,6 +752,28 @@ img {
   }
 }
 
+.pawprint-info-image {
+  width: 96px;
+  height: 64px;
+  margin: 0 10px 0 0;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+}
+
+.pawprint-info-text {
+  width: calc(100% - 106px);
+  margin: -4px 0 0;
+}
+
+.pawprint-info-text h3 {
+  margin: 0;
+  font-size: 1em;
+}
+
 .pawprint-memo {
   width: calc(50% - 54px);
 }
@@ -757,6 +781,7 @@ img {
 @media screen and (max-width: 768px) {
   .pawprint-memo {
     width: 100%;
+    margin: 0.5em 0 0 34px;
   }
 }
 

--- a/app/views/pawprints/_lines.html.erb
+++ b/app/views/pawprints/_lines.html.erb
@@ -7,9 +7,22 @@
         <%= image_tag(user.icon_url, size: "24x24") %>
       </div>
       <div class="pawprint-info">
-        <%= link_to("@" + user.name, user_path(user_name: user.name)) %>
-        <span>pawed on <%= pawprint.created_at.strftime("%Y-%m-%d %H:%M") %></span><br>
-        <%= link_to(item.title, item.url, target: "_blank") %>
+        <div class="pawprint-info-image">
+          <%= link_to(item.url, target: "_blank") do %>
+            <%= image_tag(item.image_url_or_placeholder, width: "100%", height: "100%") %>
+          <% end %>
+        </div>
+        <div class="pawprint-info-text">
+          <%= link_to("@" + user.name, user_path(user_name: user.name)) %>
+          <span>pawed on <br class="br-sp"/><%= pawprint.created_at.strftime("%Y-%m-%d %H:%M") %></span><br>
+          <h3>
+            <%= link_to(item.title, item.url, target: "_blank") %>
+          </h3>
+          <span class="card-channel">
+            <%= image_tag(item.channel.favicon_url, size: "16x16") %>
+            <%= link_to(item.channel.title, item.channel) %>
+          </span>
+        </div>
       </div>
       <% if pawprint.memo.present? %>
       <div class="pawprint-memo">


### PR DESCRIPTION
Pawprintsページにて各アイテムの画像とチャンネルリンクを追加しました🎨

特に、チャンネルリンクを追加したことで、これまで「他ユーザーさんのPawprintsきっかけで自分がPawする」にあたっての動線が非常に難解だったのを少し改善できる見込みです。

ゆくゆくは、Pawprintsページから直接「追いPaw」できるようにしたい🚀