### PR TITLE
Item にフィードの Entry の情報をまるごと保存する

### DIFF
--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -165,6 +165,7 @@ class Channel < ApplicationRecord
         url: encoded_url,
         image_url: image_url,
         published_at: entry.published,
+        data: entry.to_h,
       }
       self.items.find_or_initialize_by(guid: guid).update(parameters)
     end

--- a/db/migrate/20240603083752_add_data_column_to_items_table.rb
+++ b/db/migrate/20240603083752_add_data_column_to_items_table.rb
@@ -1,0 +1,5 @@
+class AddDataColumnToItemsTable < ActiveRecord::Migration[7.1]
+  def change
+    add_column :items, :data, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_10_075930) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_03_083752) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -53,6 +53,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_10_075930) do
     t.datetime "published_at", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.jsonb "data"
     t.index ["channel_id", "guid"], name: "index_items_on_channel_id_and_guid", unique: true
     t.index ["channel_id"], name: "index_items_on_channel_id"
     t.index ["published_at"], name: "index_items_on_published_at"


### PR DESCRIPTION
- https://github.com/kairan-app/feeeed/issues/135
- https://github.com/kairan-app/feeeed/issues/193

を考える中でフィードの Entry の中の enclosure_url を Item に保存したいと考えた。ミニマムの一手として Item モデルに enclosure_url カラムを生やす案が浮かぶが、これだと扱いたいデータが増えるたびにカラム追加を行うことになるし、すでに保存されている Item の分をさかのぼってデータ取得しようと思うとなかなかたいへんだ、と気付くに至った。

そこで、フィードの Entry 情報をまるごと JSON にして突っ込んでおく data カラムを用意し、これからフェッチする分については生データに近い情報を保持しておくことにする。こうすれば、いつかの未来に「このデータも活用したい」となったときにすぐに活用できるようになる。わいわい。
