### PR TITLE
Unreads に audio/video/text のフィルタを実装する

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1511,7 +1511,7 @@ footer ul li a {
   border-radius: 4px;
 }
 
-.unreads-nav-button a:hover {
+.unreads-nav-button a:hover, .unreads-nav-button a.active {
   background-color: #3d8bcd;
   color: #ffffff;
   text-decoration: none;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1166,7 +1166,7 @@ a.remove-from-my-own:hover {
   margin: 0 20px 20px 0;
   padding: 0 10px;
   background-color: #ffffff;
-  border-radius: 8px;
+  border-radius: 0 8px 8px 8px;
 }
 
 .channel-and-items-component h3 {
@@ -1530,6 +1530,39 @@ footer ul li a {
 .unreads-nav-button a:hover, .unreads-nav-button a.active {
   background-color: #3d8bcd;
   color: #ffffff;
+  text-decoration: none;
+}
+
+.unreads-tab {
+  display: flex;
+  width: 100%;
+  margin: 0.5em 0 0;
+}
+
+.unreads-tab a {
+  width: 120px;
+  margin: 0 0.5em 0 0;
+  padding: 0.5em 0;
+  background-color: #cccccc;
+  color: #555555;
+  border-radius: 6px 6px 0px 0px;
+  text-align: center;
+}
+
+@media screen and (max-width: 768px) {
+  .unreads-tab a {
+    width: 80px;
+  }
+}
+
+.unreads-tab a.active, .unreads-tab a.active:hover {
+  background-color: #ffffff;
+  color: #000000;
+}
+
+.unreads-tab a:hover {
+  background-color: #dddddd;
+  color: #000000;
   text-decoration: none;
 }
 

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1318,17 +1318,33 @@ a.remove-from-my-own:hover {
   }
 }
 
-.channel-and-items-component-item-paw {
-  display: flex;
+.channel-and-items-component-item-player-and-paw {
   width: calc(50% - 20px);
   margin: 0 0 0 20px;
+  padding: 0.75em 0;
 }
 
 @media screen and (max-width: 768px) {
-  .channel-and-items-component-item-paw {
+  .channel-and-items-component-item-player-and-paw {
     width: 100%;
-    margin: 0 0 1em;
+    margin: -0.25em 0 0;
+    padding: 0 0 0.75em;
   }
+}
+
+.channel-and-items-component-item-player {
+  width: 100%;
+  margin: 0 0 0.25em;
+}
+
+.channel-and-items-component-item-player audio {
+  height: 36px;
+}
+
+.channel-and-items-component-item-paw {
+  display: flex;
+  width: 100%;
+  margin: 0;
 }
 
 .channel-and-items-component-item-skip {

--- a/app/controllers/my/unreads_controller.rb
+++ b/app/controllers/my/unreads_controller.rb
@@ -1,11 +1,12 @@
 class My::UnreadsController < MyController
   def show
-    mode = (params[:mode].in?(%w[text audio video]) ? params[:mode] : nil)&.to_sym
     @range_days = (params[:range_days].presence || session[:range_days] || 3).to_i
-    @channel_and_items = current_user.unread_items_grouped_by_channel(range_days: @range_days, mode: mode)
+    @mode = params[:mode].in?(%w[text audio video]) ? params[:mode].to_sym : nil
+    @channel_and_items = current_user.unread_items_grouped_by_channel(range_days: @range_days, mode: @mode)
 
     session[:range_days] = @range_days
 
     @title = "Unreads"
+    @title += " #{@mode}s" if @mode
   end
 end

--- a/app/controllers/my/unreads_controller.rb
+++ b/app/controllers/my/unreads_controller.rb
@@ -1,17 +1,10 @@
 class My::UnreadsController < MyController
   def show
+    mode = (params[:mode].in?(%w[text audio video]) ? params[:mode] : nil)&.to_sym
     @range_days = (params[:range_days].presence || session[:range_days] || 3).to_i
-    session[:range_days] = @range_days
+    @channel_and_items = current_user.unread_items_grouped_by_channel(range_days: @range_days, mode: mode)
 
-    @channel_and_items =
-      current_user.subscribed_items.
-      preload(:channel).
-      where("NOT EXISTS (SELECT 1 FROM pawprints WHERE pawprints.item_id = items.id AND pawprints.user_id = ?)", current_user.id).
-      where("NOT EXISTS (SELECT 1 FROM item_skips WHERE item_skips.item_id = items.id AND item_skips.user_id = ?)", current_user.id).
-      where("items.created_at > ?", @range_days.days.ago).
-      group_by(&:channel).
-      sort_by { |_, items| items.map(&:created_at).max }.
-      reverse
+    session[:range_days] = @range_days
 
     @title = "Unreads"
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -22,6 +22,28 @@ class Item < ApplicationRecord
     image_url.presence || "https://placehold.jp/30/cccccc/ffffff/270x180.png?text=#{self.title}"
   end
 
+  def enclosure_type
+    self.data&.dig("enclosure_type")
+  end
+
+  def enclosure_url
+    self.data&.dig("enclosure_url")
+  end
+
+  def audio_enclosure_url
+    return nil if enclosure_type.nil?
+    return nil unless enclosure_type.start_with?("audio/")
+
+    enclosure_url
+  end
+
+  def video_enclosure_url
+    return nil if enclosure_type.nil?
+    return nil unless enclosure_type.start_with?("video/")
+
+    enclosure_url
+  end
+
   def to_discord_embed
     {
       author: { name: [channel.title, URI.parse(self.url).host].join(" | "), url: channel.site_url },

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -55,4 +55,27 @@ class User < ApplicationRecord
   def unskip(item)
     item_skips.find_by(item: item).destroy
   end
+
+  def unread_items_grouped_by_channel(range_days: 7, mode: :all)
+    self.
+    subscribed_items.
+    preload(:channel).
+    where("NOT EXISTS (SELECT 1 FROM pawprints WHERE pawprints.item_id = items.id AND pawprints.user_id = ?)", self.id).
+    where("NOT EXISTS (SELECT 1 FROM item_skips WHERE item_skips.item_id = items.id AND item_skips.user_id = ?)", self.id).
+    where("items.created_at > ?", range_days.days.ago).
+    select {
+      if mode == :audio
+        _1.audio_enclosure_url.present?
+      elsif mode == :video
+        _1.video_enclosure_url.present?
+      elsif mode == :text
+        _1.audio_enclosure_url.nil? && _1.video_enclosure_url.nil?
+      else
+        true
+      end
+    }.
+    group_by(&:channel).
+    sort_by { |_, items| items.map(&:created_at).max }.
+    reverse
+  end
 end

--- a/app/views/my/unreads/show.html.erb
+++ b/app/views/my/unreads/show.html.erb
@@ -4,6 +4,12 @@
   <%= link_to("← " + (@range_days - 1).to_s + " days", unreads_path(range_days: @range_days - 1)) %>
   <%= link_to((@range_days + 1).to_s + " days →", unreads_path(range_days: @range_days + 1)) %>
 </div>
+<div class="unreads-nav-button">
+  <%= link_to("All", unreads_path) %>
+  <%= link_to("Text", unreads_path(mode: "text")) %>
+  <%= link_to("Audio", unreads_path(mode: "audio")) %>
+  <%= link_to("Video", unreads_path(mode: "video")) %>
+</div>
 <% @channel_and_items.each do |channel, items| %>
   <div class="channel-and-items-component channel-and-items-component-unreads">
     <h3 class="channel-and-items-component-channel">
@@ -28,7 +34,14 @@
               <h4>
                 <%= item.title %>
               </h4>
-              <%= item.published_at.strftime("%Y-%m-%d %H:%M") %>
+              <p>
+                <%= item.published_at.strftime("%Y-%m-%d %H:%M") %>
+              </p>
+              <% if item.audio_enclosure_url %>
+              <p>
+                <audio style="width: 100%;" src="<%= item.audio_enclosure_url %>" controls></audio>
+              </p>
+              <% end %>
             </div>
           <% end %>
           <div class="channel-and-items-component-item-paw">

--- a/app/views/my/unreads/show.html.erb
+++ b/app/views/my/unreads/show.html.erb
@@ -4,11 +4,11 @@
   <%= link_to("← " + (@range_days - 1).to_s + " days", unreads_path(range_days: @range_days - 1)) %>
   <%= link_to((@range_days + 1).to_s + " days →", unreads_path(range_days: @range_days + 1)) %>
 </div>
-<div class="unreads-nav-button">
+
+<div class="unreads-tab">
   <%= link_to("All", unreads_path, class: @mode.nil? ? "active" : nil) %>
   <%= link_to("Text", unreads_path(mode: "text"), class: @mode == :text ? "active" : nil) %>
   <%= link_to("Audio", unreads_path(mode: "audio"), class: @mode == :audio ? "active" : nil) %>
-  <%= link_to("Video", unreads_path(mode: "video"), class: @mode == :video ? "active" : nil) %>
 </div>
 <% @channel_and_items.each do |channel, items| %>
   <div class="channel-and-items-component channel-and-items-component-unreads">

--- a/app/views/my/unreads/show.html.erb
+++ b/app/views/my/unreads/show.html.erb
@@ -5,10 +5,10 @@
   <%= link_to((@range_days + 1).to_s + " days →", unreads_path(range_days: @range_days + 1)) %>
 </div>
 <div class="unreads-nav-button">
-  <%= link_to("All", unreads_path) %>
-  <%= link_to("Text", unreads_path(mode: "text")) %>
-  <%= link_to("Audio", unreads_path(mode: "audio")) %>
-  <%= link_to("Video", unreads_path(mode: "video")) %>
+  <%= link_to("All", unreads_path, class: @mode.nil? ? "active" : nil) %>
+  <%= link_to("Text", unreads_path(mode: "text"), class: @mode == :text ? "active" : nil) %>
+  <%= link_to("Audio", unreads_path(mode: "audio"), class: @mode == :audio ? "active" : nil) %>
+  <%= link_to("Video", unreads_path(mode: "video"), class: @mode == :video ? "active" : nil) %>
 </div>
 <% @channel_and_items.each do |channel, items| %>
   <div class="channel-and-items-component channel-and-items-component-unreads">

--- a/app/views/my/unreads/show.html.erb
+++ b/app/views/my/unreads/show.html.erb
@@ -37,19 +37,21 @@
               <p>
                 <%= item.published_at.strftime("%Y-%m-%d %H:%M") %>
               </p>
-              <% if item.audio_enclosure_url %>
-              <p>
-                <audio style="width: 100%;" src="<%= item.audio_enclosure_url %>" controls></audio>
-              </p>
-              <% end %>
             </div>
           <% end %>
-          <div class="channel-and-items-component-item-paw">
-            <div class="channel-and-items-component-item-skip">
-              <%= link_to("Skip", item_skip_path(item), data: { turbo_method: :post }) %>
-            </div>
-            <div class="channel-and-items-component-item-memo">
-              <%= render(partial: "items/pawprint_form", locals: { item: item, pawprint: nil }) %>
+          <div class="channel-and-items-component-item-player-and-paw">
+            <% if item.audio_enclosure_url %>
+              <div class="channel-and-items-component-item-player">
+                <audio style="width: 100%;" src="<%= item.audio_enclosure_url %>" controls controlslist="nodownload"></audio>
+              </div>
+            <% end %>
+            <div class="channel-and-items-component-item-paw">
+              <div class="channel-and-items-component-item-skip">
+                <%= link_to("Skip", item_skip_path(item), data: { turbo_method: :post }) %>
+              </div>
+              <div class="channel-and-items-component-item-memo">
+                <%= render(partial: "items/pawprint_form", locals: { item: item, pawprint: nil }) %>
+              </div>
             </div>
           </div>
         </li>


### PR DESCRIPTION
- https://github.com/kairan-app/feeeed/pull/198

によって Item モデルに enclosure_url と enclosure_type の情報が保存されるようになったので、これを活用して Unreads ページに audio/video/text を分けて表示するモードを実装してみます。
