### PR TITLE
Ruby 3.3.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1
 
-FROM ruby:3.3.1
+FROM ruby:3.3.2
 
 RUN apt-get update -qq && apt-get install -y nodejs postgresql-client
 
@@ -10,6 +10,7 @@ WORKDIR /app
 COPY Gemfile /app/Gemfile
 COPY Gemfile.lock /app/Gemfile.lock
 
+RUN gem install bundler
 RUN bundle install
 
 COPY . /app

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-ruby "3.3.1"
+ruby "3.3.2"
 
 gem "rails", "~> 7.1.3"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -392,7 +392,7 @@ DEPENDENCIES
   web-console
 
 RUBY VERSION
-   ruby 3.3.1p55
+   ruby 3.3.2p78
 
 BUNDLED WITH
-   2.5.5
+   2.5.11


### PR DESCRIPTION
Ruby の 3.3.2 がリリースされたので、さっそく使います :gem:
