### PR TITLE
Google アカウントのプロフィールアイコンが変わったときは追随するが、別の画像が登録されている場合には上書きしない

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -20,7 +20,15 @@ class SessionsController < ApplicationController
     user = User.find_or_initialize_by(google_guid: payload["sub"])
     user.email ||= email
     user.name ||= local_part
-    user.icon_url = payload["picture"]
+
+    if user.icon_url
+      if user.icon_url.include?("googleusercontent.com")
+        user.icon_url = payload["picture"]
+      end
+    else
+      user.icon_url = payload["picture"]
+    end
+
     user.save
 
     log_in(user)


### PR DESCRIPTION
アルファ・テスト期間の場当たり的な対応という感じ :zany_face:
利用者が自由にプロフィールアイコンを変更できるようになったらまるごと見直し対象になるでしょう :dash:
