### PR TITLE
スタイリング @ 2024-06-19

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1377,12 +1377,12 @@ a.remove-from-my-own:hover {
   }
 }
 
-.channel-and-items-component-item-player {
+.audio-player {
   width: 100%;
   margin: 0.5em 0 -0.5em;
 }
 
-.channel-and-items-component-item-player audio {
+.audio-player audio {
   height: 36px;
 }
 

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1379,7 +1379,7 @@ a.remove-from-my-own:hover {
 
 .channel-and-items-component-item-player {
   width: 100%;
-  margin: 0 0 0.25em;
+  margin: 0.5em 0 -0.5em;
 }
 
 .channel-and-items-component-item-player audio {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1208,10 +1208,14 @@ a.remove-from-my-own:hover {
 
 .channel-and-items-component {
   width: calc(33.33333% - 20px);
-  margin: 0 20px 20px 0;
+  margin: 0 20px 0 0;
   padding: 0 10px;
   background-color: #ffffff;
-  border-radius: 0 8px 8px 8px;
+  border-bottom: solid 6px #dddddd;
+}
+
+.channel-and-items-component:last-of-type {
+  border-bottom: none;
 }
 
 .channel-and-items-component h3 {

--- a/app/views/my/unreads/show.html.erb
+++ b/app/views/my/unreads/show.html.erb
@@ -39,7 +39,7 @@
               </p>
             </div>
             <% if item.audio_enclosure_url %>
-              <div class="channel-and-items-component-item-player">
+              <div class="audio-player">
                 <audio style="width: 100%;" src="<%= item.audio_enclosure_url %>" controls controlslist="nodownload"></audio>
               </div>
             <% end %>

--- a/app/views/my/unreads/show.html.erb
+++ b/app/views/my/unreads/show.html.erb
@@ -38,13 +38,13 @@
                 <%= item.published_at.strftime("%Y-%m-%d %H:%M") %>
               </p>
             </div>
-          <% end %>
-          <div class="channel-and-items-component-item-player-and-paw">
             <% if item.audio_enclosure_url %>
               <div class="channel-and-items-component-item-player">
                 <audio style="width: 100%;" src="<%= item.audio_enclosure_url %>" controls controlslist="nodownload"></audio>
               </div>
             <% end %>
+          <% end %>
+          <div class="channel-and-items-component-item-player-and-paw">
             <div class="channel-and-items-component-item-paw">
               <div class="channel-and-items-component-item-skip">
                 <%= link_to("Skip", item_skip_path(item), data: { turbo_method: :post }) %>

--- a/app/views/pawprints/_lines.html.erb
+++ b/app/views/pawprints/_lines.html.erb
@@ -18,6 +18,11 @@
             <%= link_to(item.channel.title, item.channel) %>
           </p>
         </div>
+        <% if item.audio_enclosure_url %>
+          <div class="audio-player">
+            <audio style="width: 100%;" src="<%= item.audio_enclosure_url %>" controls controlslist="nodownload"></audio>
+          </div>
+        <% end %>
       </div>
       <div class="pawprint-paw">
         <div class="pawprint-user">


### PR DESCRIPTION
下記を進めましたっ🍖

- Pawprintsページでも Audio Player を表示
- 上記に伴い、Unreadsページの Audio Player レイアウトを Paw 側から Item 側に移動
- Unreads ページのタブが、一番上のチャンネルだけにかかっているように見えてしまっていたので修正