### PR TITLE
ChannelGroupWebhook モデルを導入する

### DIFF
--- a/app/jobs/channel_group_webhook_notifier_job.rb
+++ b/app/jobs/channel_group_webhook_notifier_job.rb
@@ -1,0 +1,7 @@
+class ChannelGroupWebhookNotifierJob < ApplicationJob
+  queue_as :default
+
+  def perform(channel_group_webhook_id)
+    ChannelGroupWebhook.find(channel_group_webhook_id).notify
+  end
+end

--- a/app/models/channel_group.rb
+++ b/app/models/channel_group.rb
@@ -1,6 +1,8 @@
 class ChannelGroup < ApplicationRecord
   has_many :channel_groupings, dependent: :destroy
   has_many :channels, through: :channel_groupings
+  has_many :items, through: :channels
+  has_many :channel_group_webhooks, dependent: :destroy
 
   validates :name, presence: true, length: { maximum: 64 }
 end

--- a/app/models/channel_group_webhook.rb
+++ b/app/models/channel_group_webhook.rb
@@ -3,4 +3,20 @@ class ChannelGroupWebhook < ApplicationRecord
 
   validates :channel_group_id, presence: true
   validates :url, presence: true, length: { maximum: 2083 }, format: { with: URI.regexp }
+
+  def notify_items_to_discord(since: nil)
+    at = since || last_notified_at || 6.hours.ago
+    items = channel_group.items.where('created_at > ?', at).order(:created_at)
+    return if items.empty?
+
+    items.group_by(&:channel).sort_by { |_, items| items.map(&:created_at).max }.each do |channel, sub_items|
+      content = "#{channel.title} 's new items 📨"
+      embeds = sub_items.sort_by(&:id).reverse.take(3).map(&:to_discord_embed)
+
+      sleep 2
+      Faraday.post(
+        url, { content:, embeds: }.to_json, "Content-Type": "application/json"
+      )
+    end
+  end
 end

--- a/app/models/channel_group_webhook.rb
+++ b/app/models/channel_group_webhook.rb
@@ -4,6 +4,16 @@ class ChannelGroupWebhook < ApplicationRecord
   validates :channel_group_id, presence: true
   validates :url, presence: true, length: { maximum: 2083 }, format: { with: URI.regexp }
 
+  class << self
+    def notify
+      find_each { ChannelGroupWebhookNotifierJob.perform_later(_1.id) }
+    end
+  end
+
+  def notify
+    notify_items_to_discord
+  end
+
   def notify_items_to_discord(since: nil)
     at = since || last_notified_at || 6.hours.ago
     items = channel_group.items.where("items.created_at >= ?", at)

--- a/app/models/channel_group_webhook.rb
+++ b/app/models/channel_group_webhook.rb
@@ -6,17 +6,19 @@ class ChannelGroupWebhook < ApplicationRecord
 
   def notify_items_to_discord(since: nil)
     at = since || last_notified_at || 6.hours.ago
-    items = channel_group.items.where('created_at > ?', at).order(:created_at)
+    items = channel_group.items.where("items.created_at >= ?", at)
     return if items.empty?
 
     items.group_by(&:channel).sort_by { |_, items| items.map(&:created_at).max }.each do |channel, sub_items|
       content = "#{channel.title} 's new items 📨"
-      embeds = sub_items.sort_by(&:id).reverse.take(3).map(&:to_discord_embed)
+      embeds = sub_items.sort_by(&:id).last(3).map(&:to_discord_embed)
 
       sleep 2
       Faraday.post(
         url, { content:, embeds: }.to_json, "Content-Type": "application/json"
       )
     end
+
+    touch(:last_notified_at)
   end
 end

--- a/app/models/channel_group_webhook.rb
+++ b/app/models/channel_group_webhook.rb
@@ -1,0 +1,6 @@
+class ChannelGroupWebhook < ApplicationRecord
+  belongs_to :channel_group
+
+  validates :channel_group_id, presence: true
+  validates :url, presence: true, length: { maximum: 2083 }, format: { with: URI.regexp }
+end

--- a/db/migrate/20240618235702_create_channel_group_webhooks.rb
+++ b/db/migrate/20240618235702_create_channel_group_webhooks.rb
@@ -1,0 +1,11 @@
+class CreateChannelGroupWebhooks < ActiveRecord::Migration[7.1]
+  def change
+    create_table :channel_group_webhooks do |t|
+      t.references :channel_group, null: false, foreign_key: true
+      t.string :url, null: false, limit: 2083
+      t.datetime :last_notified_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_12_084547) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_18_235702) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "channel_group_webhooks", force: :cascade do |t|
+    t.bigint "channel_group_id", null: false
+    t.string "url", limit: 2083, null: false
+    t.datetime "last_notified_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["channel_group_id"], name: "index_channel_group_webhooks_on_channel_group_id"
+  end
 
   create_table "channel_groupings", force: :cascade do |t|
     t.bigint "channel_id", null: false
@@ -139,6 +148,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_12_084547) do
     t.index ["name"], name: "index_users_on_name", unique: true
   end
 
+  add_foreign_key "channel_group_webhooks", "channel_groups"
   add_foreign_key "channel_groupings", "channel_groups"
   add_foreign_key "channel_groupings", "channels"
   add_foreign_key "channel_stoppers", "channels"


### PR DESCRIPTION
ChannelGroup にくっつけて、そこの新着 Item を Webhook で通知してくれる ChannelGroupWebhook モデルを導入します。ここでは

- テーブルのスキーマを定義する
- モデルを実装する
- Discord への通知処理を実装する

までを扱います。とりあえずこいつを Production 環境で動かしてみて、通知処理が期待通りに動くかを確かめます。

そのあとで ChannelGroupWebhook を作成するフォーム等を追いつかせていきます。
