### PR TITLE
入力として受け取った feed_url を採用する

### DIFF
--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -151,7 +151,7 @@ class Channel < ApplicationRecord
       p ["Fetching", entry.published, entry.title, entry.url]
       next if entry.title.blank?
 
-      url = entry.url || self.site_url
+      url = (entry.url || self.site_url).strip
       encoded_url = url.chars.map { |c| c.bytesize > 1 ? URI.encode_www_form_component(c) : c }.join
 
       guid = entry.entry_id || entry.url

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -51,6 +51,7 @@ class Channel < ApplicationRecord
       return nil if feed_url.nil?
 
       feed = Feedjira.parse(Faraday.get(feed_url).body)
+      feed.url = feed_url
 
       parameters =
         case feed
@@ -69,6 +70,7 @@ class Channel < ApplicationRecord
 
     def save_from(feed_url)
       feed = Feedjira.parse(Faraday.get(feed_url).body)
+      feed.url = feed_url
 
       parameters =
         case feed


### PR DESCRIPTION
説明がむつかしいが… この変更によって登録できるフィードが増えるのです :dash:

- フィードの中に「このフィードの URL はこれです」の情報が含まれていないケース
  - 実例 https://www.city.matsumoto.nagano.jp/rss/10/list1.xml
  - これはフィードとして invalid なので「うちでは扱えません」としてもいいのだけれど :relieved:
- フィードの中の「このフィードの URL はこれです」の前後に空白文字が入っているケース
  - 実例 https://pages.d-sato.net/feed.xml
  - `"\n    https://pages.d-sato.net/feed.xml"` みたいになっていると GET に失敗する

これらのケースに該当するフィードでも登録できるように、処理に工夫を加えます。独特の知見が貯まっていく… :thinking:
