### PR TITLE
ChannelGroup と User の関係性を表現する Membership モデルを導入する

### DIFF
--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -1,0 +1,17 @@
+class MembershipsController < ApplicationController
+  before_action :login_required
+
+  def create
+    channel_group = ChannelGroup.find(params[:id])
+    current_user.join_to(channel_group)
+
+    redirect_to channel_group
+  end
+
+  def destroy
+    channel_group = ChannelGroup.find(params[:id])
+    current_user.leave(channel_group)
+
+    redirect_to channel_group
+  end
+end

--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -3,7 +3,8 @@ class MembershipsController < ApplicationController
 
   def create
     channel_group = ChannelGroup.find(params[:id])
-    current_user.join_to(channel_group)
+    current_user.join(channel_group)
+    DiscoPosterJob.perform_later(content: "@#{current_user.name} joined the channel group: #{channel_group.name}")
 
     redirect_to channel_group
   end
@@ -11,6 +12,7 @@ class MembershipsController < ApplicationController
   def destroy
     channel_group = ChannelGroup.find(params[:id])
     current_user.leave(channel_group)
+    DiscoPosterJob.perform_later(content: "@#{current_user.name} left the channel group: #{channel_group.name}")
 
     redirect_to channel_group
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,6 +7,7 @@ class UsersController < ApplicationController
     @user = User.find_by(name: params[:user_name])
     @owned_channels = @user.owned_channels.order("ownerships.id DESC")
     @subscribed_channels = @user.subscribed_channels.order("subscriptions.id DESC")
+    @channel_groups = @user.channel_groups.order("channel_groups.id DESC")
 
     @title = "@" + @user.name
   end

--- a/app/models/channel_group.rb
+++ b/app/models/channel_group.rb
@@ -2,6 +2,8 @@ class ChannelGroup < ApplicationRecord
   has_many :channel_groupings, dependent: :destroy
   has_many :channels, through: :channel_groupings
   has_many :items, through: :channels
+  has_many :memberships, dependent: :destroy
+  has_many :users, through: :memberships
   has_many :channel_group_webhooks, dependent: :destroy
 
   validates :name, presence: true, length: { maximum: 64 }

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -1,0 +1,7 @@
+class Membership < ApplicationRecord
+  belongs_to :user
+  belongs_to :channel_group
+
+  validates :user_id, presence: true, uniqueness: { scope: :channel_group_id }
+  validates :channel_group_id, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,8 @@ class User < ApplicationRecord
   has_many :subscriptions, dependent: :destroy
   has_many :subscribed_channels, through: :subscriptions, source: :channel
   has_many :subscribed_items, through: :subscribed_channels, source: :items
+  has_many :memberships, dependent: :destroy
+  has_many :channel_groups, through: :memberships
   has_many :pawprints, dependent: :destroy
   has_many :pawed_items, through: :pawprints, source: :item
   has_many :item_skips, dependent: :destroy
@@ -46,6 +48,14 @@ class User < ApplicationRecord
 
   def pawed?(item)
     pawed_items.include?(item)
+  end
+
+  def join_to(channel_group)
+    memberships.create(channel_group: channel_group)
+  end
+
+  def leave(channel_group)
+    memberships.find_by(channel_group: channel_group)&.destroy
   end
 
   def skip(item)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,7 +50,7 @@ class User < ApplicationRecord
     pawed_items.include?(item)
   end
 
-  def join_to(channel_group)
+  def join(channel_group)
     memberships.create(channel_group: channel_group)
   end
 

--- a/app/views/channel_groups/show.html.erb
+++ b/app/views/channel_groups/show.html.erb
@@ -9,6 +9,13 @@
       </div>
     </div>
   <% end %>
+  <% if logged_in? %>
+    <% if @channel_group.users.include?(current_user) %>
+      <p><%= link_to("Leave this channel group", channel_group_membership_path(@channel_group), data: { turbo_method: :delete }) %></p>
+    <% else %>
+      <p><%= link_to("Join to this channel group", channel_group_membership_path(@channel_group), data: { turbo_method: :post }) %></p>
+    <% end %>
+  <% end %>
   <p><%= @channel_group.channels.count %> channels</p>
   <%= render(partial: "channels/cards", locals: { channels: @channel_group.channels }) %>
 </section>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -8,6 +8,15 @@
   </div>
 </div>
 
+<% if @channel_groups.exists? %>
+<h3>Channel Groups</h3>
+<ul>
+  <% @channel_groups.each do |channel_group| %>
+    <li><%= link_to(channel_group.name, channel_group) %></li>
+  <% end %>
+</ul>
+<% end %>
+
 <% if @owned_channels.exists? %>
 <h3>Owned Channels</h3>
 <%= render(partial: "channels/cards", locals: { channels: @owned_channels }) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,9 @@ Rails.application.routes.draw do
   get    "/channel_groups/new",                to: "channel_groups#new",
                                                as: "new_channel_group"
   post   "/channel_groupings",                 to: "channel_groupings#create"
+  post   "/channel_groups/:id/membership",     to: "memberships#create",
+                                               as: "channel_group_membership"
+  delete "/channel_groups/:id/membership",     to: "memberships#destroy"
   get    "/pawprints",                         to: "pawprints#index"
   post   "/notification_webhooks",             to: "notification_webhooks#create"
   delete "/notification_webhooks/:id",         to: "notification_webhooks#destroy",

--- a/db/migrate/20240623123827_create_memberships.rb
+++ b/db/migrate/20240623123827_create_memberships.rb
@@ -1,0 +1,12 @@
+class CreateMemberships < ActiveRecord::Migration[7.1]
+  def change
+    create_table :memberships do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :channel_group, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :memberships, %i[user_id channel_group_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_18_235702) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_23_123827) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -84,6 +84,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_18_235702) do
     t.index ["published_at"], name: "index_items_on_published_at"
   end
 
+  create_table "memberships", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "channel_group_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["channel_group_id"], name: "index_memberships_on_channel_group_id"
+    t.index ["user_id", "channel_group_id"], name: "index_memberships_on_user_id_and_channel_group_id", unique: true
+    t.index ["user_id"], name: "index_memberships_on_user_id"
+  end
+
   create_table "notification_emails", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "email", null: false
@@ -155,6 +165,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_18_235702) do
   add_foreign_key "item_skips", "items"
   add_foreign_key "item_skips", "users"
   add_foreign_key "items", "channels"
+  add_foreign_key "memberships", "channel_groups"
+  add_foreign_key "memberships", "users"
   add_foreign_key "notification_emails", "users"
   add_foreign_key "notification_webhooks", "users"
   add_foreign_key "ownerships", "channels"


### PR DESCRIPTION
まずは二値的に「この ChannelGroup に参加する」を表現できるようにします :v:

このあとの展開として考えているのは

- 自分が参加している ChannelGroup は、Unreads ページに反映される
- Membership の内訳として「Member / Editor / Manager」のような区分を追加し、アクセス制御を実現する

あたりです。やっていくぞ〜〜〜 :dash:
