### PR TITLE
HTTP GET の簡易クライアントを用意する

### DIFF
--- a/app/jobs/item_creation_notifier_job.rb
+++ b/app/jobs/item_creation_notifier_job.rb
@@ -12,7 +12,7 @@ class ItemCreationNotifierJob < ApplicationJob
 
   def should_notify?(item)
     # 新しい方から見て3件以内のItemのみ通知する
-    feed = Feedjira.parse(Faraday.get(item.channel.feed_url).body)
+    feed = Feedjira.parse(Httpc.get(item.channel.feed_url))
     return true if item.guid.in?(feed.entries.sort_by(&:published).reverse.take(2).map(&:entry_id))
 
     false

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -50,7 +50,7 @@ class Channel < ApplicationRecord
       feed_url = Feedbag.find(url).first
       return nil if feed_url.nil?
 
-      feed = Feedjira.parse(Faraday.get(feed_url).body)
+      feed = Feedjira.parse(Httpc.get(feed_url))
       feed.url = feed.url.strip if feed.url
 
       parameters =
@@ -69,7 +69,7 @@ class Channel < ApplicationRecord
     end
 
     def save_from(feed_url)
-      feed = Feedjira.parse(Faraday.get(feed_url).body)
+      feed = Feedjira.parse(Httpc.get(feed_url))
       feed.url = feed.url.strip if feed.url
 
       parameters =
@@ -136,7 +136,7 @@ class Channel < ApplicationRecord
   end
 
   def fetch_and_save_items(mode = :only_new)
-    feed = Feedjira.parse(Faraday.get(feed_url).body)
+    feed = Feedjira.parse(Httpc.get(feed_url))
 
     entries =
       if mode == :only_new

--- a/lib/httpc.rb
+++ b/lib/httpc.rb
@@ -1,0 +1,27 @@
+require "faraday"
+require "faraday_middleware"
+require "faraday-cookie_jar"
+
+class Httpc
+  def self.get(url)
+    connection = Faraday.new do |builder|
+      builder.use FaradayMiddleware::FollowRedirects
+      builder.use :cookie_jar
+      builder.adapter Faraday.default_adapter
+    end
+
+    response = connection.get(url)
+    handle_response(response)
+  end
+
+  private
+
+  def self.handle_response(response)
+    case response.status
+    when 200..299
+      response.body
+    else
+      raise "HTTP request failed with status #{response.status}: #{response.body}"
+    end
+  end
+end

--- a/lib/open_graph.rb
+++ b/lib/open_graph.rb
@@ -9,13 +9,7 @@ class OpenGraph
   def fetch_and_parse
     return if @url.nil?
 
-    uri = URI.parse(@url)
-    connection = Faraday.new(uri) do |builder|
-      builder.response :follow_redirects
-      builder.use :cookie_jar
-    end
-
-    @html = Nokogiri::HTML(connection.get(uri.path).body.force_encoding("UTF-8"))
+    @html = Nokogiri::HTML(Httpc.get(@url).force_encoding("UTF-8"))
     @title = @html.css("title").text
 
     metas = @html.css("meta")


### PR DESCRIPTION
これまでは Faraday.get を活用してきましたが、

- Cookie を受け入れたい
- リダイレクトに追従したい

に対応しようとすると数行のコードを書かなきゃいけなくなります。そこで Httpc.get と書くだけで上記のようなあれこれをやってくれるようなラッパークラスを用意し、今後はこれを使ってみることにします。

「さまざまなサーバを相手に HTTP GET する」という性質を持つこのアプリケーションにおいて、HTTP GET を扱うクラスが整備されていくのはおもしろいことに思えます :yum:
