### PR TITLE
Unreads の all/text/audio のフィルタを廃止する

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1636,39 +1636,6 @@ footer ul li a {
   text-decoration: none;
 }
 
-.unreads-tab {
-  display: flex;
-  width: 100%;
-  margin: 0.5em 0 0;
-}
-
-.unreads-tab a {
-  width: 120px;
-  margin: 0 0.5em 0 0;
-  padding: 0.5em 0;
-  background-color: #cccccc;
-  color: #555555;
-  border-radius: 6px 6px 0px 0px;
-  text-align: center;
-}
-
-@media screen and (max-width: 768px) {
-  .unreads-tab a {
-    width: 80px;
-  }
-}
-
-.unreads-tab a.active, .unreads-tab a.active:hover {
-  background-color: #ffffff;
-  color: #000000;
-}
-
-.unreads-tab a:hover {
-  background-color: #dddddd;
-  color: #000000;
-  text-decoration: none;
-}
-
 /* About */
 .hero-area {
   display: flex;

--- a/app/controllers/my/unreads_controller.rb
+++ b/app/controllers/my/unreads_controller.rb
@@ -1,21 +1,18 @@
 class My::UnreadsController < MyController
   def show
     @range_days = (params[:range_days].presence || session[:range_days] || 3).to_i
-    @mode = params[:mode].in?(%w[text audio video]) ? params[:mode].to_sym : nil
     @channel_group = ChannelGroup.find_by(id: params[:channel_group_id])
     @channel_groups = current_user.channel_groups.order(id: :desc)
     @channel_and_items = current_user.unread_items_grouped_by_channel(
-      range_days: @range_days, mode: @mode, channel_group: @channel_group
+      range_days: @range_days, channel_group: @channel_group
     )
     @unreads_params = {
       range_days: @range_days,
-      mode: @mode,
       channel_group_id: @channel_group&.id
     }
 
     session[:range_days] = @range_days
 
     @title = "Unreads"
-    @title += " #{@mode}s" if @mode
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -66,7 +66,7 @@ class User < ApplicationRecord
     item_skips.find_by(item: item).destroy
   end
 
-  def unread_items_grouped_by_channel(range_days: 7, mode: :all, channel_group: nil)
+  def unread_items_grouped_by_channel(range_days: 7, channel_group: nil)
     items = channel_group ? channel_group.items : subscribed_items
 
     items.
@@ -74,17 +74,6 @@ class User < ApplicationRecord
     where("NOT EXISTS (SELECT 1 FROM pawprints WHERE pawprints.item_id = items.id AND pawprints.user_id = ?)", self.id).
     where("NOT EXISTS (SELECT 1 FROM item_skips WHERE item_skips.item_id = items.id AND item_skips.user_id = ?)", self.id).
     where("items.created_at > ?", range_days.days.ago).
-    select {
-      if mode == :audio
-        _1.audio_enclosure_url.present?
-      elsif mode == :video
-        _1.video_enclosure_url.present?
-      elsif mode == :text
-        _1.audio_enclosure_url.nil? && _1.video_enclosure_url.nil?
-      else
-        true
-      end
-    }.
     group_by(&:channel).
     sort_by { |_, items| items.map(&:created_at).max }.
     reverse

--- a/app/views/my/unreads/show.html.erb
+++ b/app/views/my/unreads/show.html.erb
@@ -15,11 +15,6 @@
 </div>
 <% end %>
 
-<div class="unreads-tab">
-  <%= link_to("All", unreads_path(@unreads_params.merge(mode: nil)), class: @mode.nil? ? "active" : nil) %>
-  <%= link_to("Text", unreads_path(@unreads_params.merge(mode: "text")), class: @mode == :text ? "active" : nil) %>
-  <%= link_to("Audio", unreads_path(@unreads_params.merge(mode: "audio")), class: @mode == :audio ? "active" : nil) %>
-</div>
 <% @channel_and_items.each do |channel, items| %>
   <div class="channel-and-items-component channel-and-items-component-unreads">
     <h3 class="channel-and-items-component-channel">


### PR DESCRIPTION
- https://github.com/kairan-app/feeeed/pull/199

で実装したコンテンツの形式で絞り込む機構を廃止します。今後は ChannelGroup ごとに分けて閲覧できれば十分ではないか、と考えています。

- https://github.com/kairan-app/feeeed/pull/198

で Item に情報を持たせるようにしてそれは残るので、audio タグによる音声の再生はこれからも可能です。
