### PR TITLE
TOPとItems一覧にAudioPlayerを追加

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -629,6 +629,7 @@ header nav ul li a:hover {
 }
 
 .card-image {
+  position: relative;
   width: 100%;
   line-height: 0;
 }
@@ -1397,6 +1398,17 @@ a.remove-from-my-own:hover {
 
 .audio-player audio {
   height: 36px;
+}
+
+.audio-player-ont-the-image {
+  position: absolute;
+  bottom: 0;
+  width: 96%;
+  margin: 0.25em 2% 0.25em;
+}
+
+.audio-player-ont-the-image audio {
+  height: 30px;
 }
 
 .channel-and-items-component-item-paw {

--- a/app/views/items/_cards.html.erb
+++ b/app/views/items/_cards.html.erb
@@ -3,6 +3,11 @@
   <div class="card item-card">
     <div class="card-image">
       <%= image_tag(item.image_url_or_placeholder, width: "100%", height: "100%") %>
+      <% if item.audio_enclosure_url %>
+        <div class="audio-player audio-player-ont-the-image">
+          <audio style="width: 100%;" src="<%= item.audio_enclosure_url %>" controls controlslist="nodownload"></audio>
+        </div>
+      <% end %>
     </div>
     <h3 class="card-title"><%= link_to(item.title, item.url, target: "_blank") %></h3>
     <% if with_channel %>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -28,6 +28,11 @@
             </h4>
             <%= item.published_at.strftime("%Y-%m-%d %H:%M") %>
           </div>
+          <% if item.audio_enclosure_url %>
+            <div class="audio-player">
+              <audio style="width: 100%;" src="<%= item.audio_enclosure_url %>" controls controlslist="nodownload"></audio>
+            </div>
+          <% end %>
         <% end %>
         </li>
         <% end %>


### PR DESCRIPTION
前に Unreads や Pawprints ページで追加していた Audio Player を、以下の3ページにも表示するようにしました🚀

- トップページ（Recent Channel & Items）
- Items一覧ページ
- 各Channel詳細ページの中のItems一覧