### PR TITLE
ChannelGroup の Owner という概念を追加する

### DIFF
--- a/app/controllers/channel_groups_controller.rb
+++ b/app/controllers/channel_groups_controller.rb
@@ -19,7 +19,7 @@ class ChannelGroupsController < ApplicationController
   end
 
   def create
-    @channel_group = ChannelGroup.new(channel_group_params)
+    @channel_group = ChannelGroup.new(channel_group_params.merge(owner: current_user))
 
     if @channel_group.save
       DiscoPosterJob.perform_later(content: "@#{current_user.name} created a new channel group: #{@channel_group.name}")

--- a/app/models/channel_group.rb
+++ b/app/models/channel_group.rb
@@ -1,4 +1,5 @@
 class ChannelGroup < ApplicationRecord
+  belongs_to :owner, class_name: "User"
   has_many :channel_groupings, dependent: :destroy
   has_many :channels, through: :channel_groupings
   has_many :items, through: :channels

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,8 +4,7 @@ class User < ApplicationRecord
   has_many :subscriptions, dependent: :destroy
   has_many :subscribed_channels, through: :subscriptions, source: :channel
   has_many :subscribed_items, through: :subscribed_channels, source: :items
-  has_many :memberships, dependent: :destroy
-  has_many :channel_groups, through: :memberships
+  has_many :channel_groups, foreign_key: :owner_id, dependent: :destroy
   has_many :pawprints, dependent: :destroy
   has_many :pawed_items, through: :pawprints, source: :item
   has_many :item_skips, dependent: :destroy

--- a/app/views/channel_groupings/_form.html.erb
+++ b/app/views/channel_groupings/_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_tag(channel_groupings_path, method: :post) do |form| %>
   <%= hidden_field_tag(:channel_id, channel.id) %>
-  <%= select_tag(:channel_group_id, options_from_collection_for_select(ChannelGroup.order(id: :desc), :id, :name)) %>
+  <%= select_tag(:channel_group_id, options_from_collection_for_select(channel_groups.order(id: :desc), :id, :name)) %>
   <%= submit_tag("Add to group") %>
 <% end %>

--- a/app/views/channels/show.html.erb
+++ b/app/views/channels/show.html.erb
@@ -46,8 +46,8 @@
     <% end %>
 
     <% if logged_in? %>
-    <% if ChannelGroup.count > 0 %>
-      <%= render(partial: "channel_groupings/form", locals: { channel: @channel }) %>
+    <% if current_user.channel_groups.count > 0 %>
+      <%= render(partial: "channel_groupings/form", locals: { channel: @channel, channel_groups: current_user.channel_groups }) %>
     <% end %>
     <% end %>
   </div>

--- a/db/migrate/20240714141127_add_owner_id_to_channel_groups_table.rb
+++ b/db/migrate/20240714141127_add_owner_id_to_channel_groups_table.rb
@@ -1,0 +1,5 @@
+class AddOwnerIdToChannelGroupsTable < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :channel_groups, :owner, foreign_key: {to_table: :users}, null: false, default: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_23_123827) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_14_141127) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -37,6 +37,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_23_123827) do
     t.string "name", limit: 64, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "owner_id", default: 1, null: false
+    t.index ["owner_id"], name: "index_channel_groups_on_owner_id"
   end
 
   create_table "channel_stoppers", force: :cascade do |t|
@@ -161,6 +163,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_23_123827) do
   add_foreign_key "channel_group_webhooks", "channel_groups"
   add_foreign_key "channel_groupings", "channel_groups"
   add_foreign_key "channel_groupings", "channels"
+  add_foreign_key "channel_groups", "users", column: "owner_id"
   add_foreign_key "channel_stoppers", "channels"
   add_foreign_key "item_skips", "items"
   add_foreign_key "item_skips", "users"


### PR DESCRIPTION
- これまで ChannelGroup は誰のものでもなかった
- 公共のものという感じで存在していて、誰もが自由に Join できる状態だった
- ここで User と ChannelGroup の間のリレーションを見直す
  - Owner: ChannelGroup の唯一の主
  - Editor: ChannelGroup の編集を行える人、Owner から権限を与えてもらう
  - Member: ChannelGroup の情報を受信する人
- この Pull Request では「Owner」という概念を導入する
