### PR TITLE
Item の image_url の導出ロジックを見直す

### DIFF
--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -165,10 +165,12 @@ class Channel < ApplicationRecord
       guid = entry.entry_id || entry.url
 
       image_url =
-        if guid.start_with?("yt:video:")
+        if entry.itunes_image
+          entry.itunes_image
+        elsif guid.start_with?("yt:video:")
           "https://img.youtube.com/vi/%s/maxresdefault.jpg" % guid.sub("yt:video:", "")
         else
-          OpenGraph.new(encoded_url).image
+          OpenGraph.new(encoded_url).image rescue nil
         end
 
       parameters = {


### PR DESCRIPTION
https://anchor.fm/s/a19e5164/podcast/rss は、フィードとしては生きているのですが、どうもウェブサイト https://podcasters.spotify.com/pod/show/piupod は死んでいるようで、サイトの情報を確認しようとして 404 になっちゃうってんで、新着 Item の保存ができなくなっていました :cry:

- サイトが死んでいても、フィードが生きていれば新着 Item を扱えるようにする
- フィードの中に `<itunes:image />` タグがあればそいつの情報を優先して参照してやる

ってな変更を加えて https://anchor.fm/s/a19e5164/podcast/rss をなんとか扱えるようにします。ウェブサイトが死んでいてフィードだけ生きている、ってことがあるのだねえ。
