### PR TITLE
tailwindcss の service とも bundle の volume を共有しておく

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
     build: .
     volumes:
       - .:/app
+      - bundle:/usr/local/bundle
     command: bin/rails tailwindcss:watch[always]
 volumes:
   redis:


### PR DESCRIPTION
ルー大柴さんの語りみたいなタイトルになってしまったが、仕方あるまいて… :zany_face:

手元の Development 環境にて、docker compose up したら tailwindcss の service が「Gem が見つからん！」といって終了してしまった。たしかに、ちょっと前に以下のふたつをマージしたから bundle install しなきゃいけなくて、

- https://github.com/kairan-app/feeeed/pull/232
- https://github.com/kairan-app/feeeed/pull/233

でも `docker compose run --rm web bundle install` はさっき実行しなかったっけ？となった。ところで sidekiq の service は元気に動いていて、docker-compose.yml をあらためて見てみると、tailwindcss とは bundle の volume を共有していなかったじゃん、と気付いた。

これで解決するはず！