### PR TITLE
Unreads ページにて、指定の Channel のすべての Items を skip する機能を実装する

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1403,13 +1403,13 @@ a.remove-from-my-own:hover {
   padding: 0.75em 1em;
 }
 
-.channel-and-items-component-item-more {
+.channel-and-items-component-item-skipper {
   padding: 0.75em 10px;
   border-top: 0.5px solid #dddddd;
 }
 
 @media screen and (max-width: 768px) {
-  .channel-and-items-component-item-more {
+  .channel-and-items-component-item-skipper {
     padding: 0.75em 0;
   }
 }

--- a/app/controllers/channel_skips_controller.rb
+++ b/app/controllers/channel_skips_controller.rb
@@ -1,0 +1,12 @@
+class ChannelSkipsController < ApplicationController
+  before_action :login_required
+
+  def create
+    @channel = Channel.find(params[:channel_id])
+
+    @items_to_skip = @channel.items.where.not(id: current_user.item_skips.pluck(:item_id))
+    @items_to_skip.each do |item|
+      current_user.skip(item)
+    end
+  end
+end

--- a/app/views/channel_skips/create.turbo_stream.erb
+++ b/app/views/channel_skips/create.turbo_stream.erb
@@ -1,0 +1,4 @@
+<% @items_to_skip.each do |item| %>
+  <%= turbo_stream.remove(item) %>
+<% end %>
+<%= turbo_stream.remove("item-skipper-#{@channel.id}") %>

--- a/app/views/my/unreads/show.html.erb
+++ b/app/views/my/unreads/show.html.erb
@@ -1,3 +1,5 @@
+<% item_count_threshold = 3 %>
+
 <h2 class="text-2xl font-bold mt-6 mb-4">Unreads</h2>
 
 <p class="unreads-nav">Showing unreads from the last <%= @range_days %> days</p>
@@ -28,7 +30,7 @@
       <% end %>
     </h3>
     <ul class="channel-and-items-component-item-list">
-      <% items.sort_by(&:published_at).reverse.take(6).each do |item| %>
+      <% items.sort_by(&:published_at).reverse.take(item_count_threshold).each do |item| %>
         <%= turbo_frame_tag(item) do %>
         <li class="unreads-list">
           <%= link_to(item.url, target: "_blank") do %>
@@ -62,9 +64,9 @@
         </li>
         <% end %>
       <% end %>
-      <% if items.size > 6 %>
-        <p class="channel-and-items-component-item-more">
-          Check out more unreads on <%= link_to(channel.title, channel) %>
+      <% if items.size > item_count_threshold %>
+        <p id= "item-skipper-<%= channel.id %>" class="channel-and-items-component-item-skipper text-center">
+          <%= link_to("Skip all items", channel_skips_path(channel_id: channel.id), data: { turbo_method: :post }, class: "inline-block leading-6 bg-[#999999] text-white p-2 rounded hover:text-white hover:bg-[#aaaaaa]") %>
         </p>
       <% end %>
     </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,8 @@ Rails.application.routes.draw do
   post   "/channels/:channel_id/subscription", to: "subscriptions#create",
                                                as: "channel_subscription"
   delete "/channels/:channel_id/subscription", to: "subscriptions#destroy"
+  post   "/channels/:channel_id/skip",         to: "channel_skips#create",
+                                               as: "channel_skips"
   get    "/items",                             to: "items#index"
   post   "/items/:item_id/pawprint",           to: "pawprints#create",
                                                as: "item_pawprint"


### PR DESCRIPTION
主に、新規に Channel をアプリケーションに追加してそれを Subscribe したとき、その Channel のすべての Items の created_at が最近の日時になってしまって Unreads ページにも乗ってくる形になる。

仮にその Channel のフィードに 100 件の Items が含まれている場合 (ポッドキャストだとちょいちょいある)、過去の全 Items が Unreads ページに反映されてしまい、Skip しようにも 100 回のタップが必要になって煩わしい。

そこで Skip all items というリンクを導入し、指定の Channel のすべての Items を一撃で Skip できるようにしてみる。他にもっといい方法があればそれを採用するのだけれど、現時点で思い付いている中ではこれが妥当な案。
