### PR TITLE
Slack 通知、画像がないときのハンドリング

### DIFF
--- a/app/models/notification_webhook.rb
+++ b/app/models/notification_webhook.rb
@@ -58,8 +58,8 @@ class NotificationWebhook < ApplicationRecord
       "NotificationWebhook performed (id: #{id}, user: @#{user.name}, mode: pawprints_to_slack, #{pawprints.count} pawprints)"
     )
 
-    pawprints.to_a.each_slice(5).with_index { |sub_pawprints, index|
-      blocks = sub_pawprints.map(&:to_slack_block).flatten
+    pawprints.each.with_index { |pawprint, index|
+      blocks = pawprint.to_slack_block
       blocks.unshift({
         type: "header",
         text: {
@@ -68,7 +68,7 @@ class NotificationWebhook < ApplicationRecord
         }
       }) if index == 0
 
-      sleep 2
+      sleep 1
       Faraday.post(
         url, { blocks:, unfurl_links: false }.to_json, "Content-Type" => "application/json"
       )

--- a/app/models/pawprint.rb
+++ b/app/models/pawprint.rb
@@ -22,23 +22,20 @@ class Pawprint < ApplicationRecord
 
   def to_slack_block
     channel = item.channel
-    [
+
+    block = [
       {
         "type": "divider"
       },
       {
         "type": "context",
         "elements": [
-          {
-            "type": "image",
-            "image_url": channel.image_url,
-            "alt_text": channel.title,
-          },
+          channel.image_url.present? ? { "type": "image", "image_url": channel.image_url, "alt_text": channel.title } : nil,
           {
             "type": "mrkdwn",
             "text": channel.site_url ? "<#{channel.site_url}|#{channel.title}>" : channel.title,
           }
-        ]
+        ].compact
       },
       {
         type: "section",
@@ -50,12 +47,17 @@ class Pawprint < ApplicationRecord
             self.created_at.strftime("%Y-%m-%d %H:%M"),
           ].compact.join("\n"),
         },
-        accessory: {
-          type: "image",
-          image_url: item.image_url,
-          alt_text: item.title,
-        },
       }
     ]
+
+    if item.image_url.present?
+      block.last[:accessory] = {
+        type: "image",
+        image_url: item.image_url,
+        alt_text: item.title,
+      }
+    end
+
+    block
   end
 end


### PR DESCRIPTION
- https://github.com/kairan-app/feeeed/issues/235

の調査を進めていて気付いたことがあったので改善を試みます。Slack の Block Kit で組み立てたメッセージを投稿するとき、画像の URL に null を指定しまうと、どうも通知そのものが行われないようです。

Discord だと、画像の URL に null を指定しても通知自体は成功する (画像指定の部分だけいい感じに無視される) ので画像の有無による条件分岐をせずに Hash を組み立てていましたが、Slack 向けにはもうちょっと真面目に Hash を組んだ方がよさそうです。
