### PR TITLE
Channel#fetch_and_save_items の処理をもうちょっといい感じにする

### DIFF
--- a/app/jobs/channel_items_updater_job.rb
+++ b/app/jobs/channel_items_updater_job.rb
@@ -1,5 +1,5 @@
 class ChannelItemsUpdaterJob < ApplicationJob
-  def perform(channel_id:, mode: :only_new)
+  def perform(channel_id:, mode: :only_recent)
     channel = Channel.find(channel_id)
     channel.fetch_and_save_items(mode)
   end

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -152,8 +152,6 @@ class Channel < ApplicationRecord
       end
 
     entries.sort_by(&:published).each do |entry|
-      sleep 2
-
       p ["Fetching", entry.published, entry.title, entry.url]
       next if entry.title.blank?
 
@@ -179,6 +177,7 @@ class Channel < ApplicationRecord
           "https://img.youtube.com/vi/%s/maxresdefault.jpg" % guid.sub("yt:video:", "")
         else
           OpenGraph.new(encoded_url).image rescue nil
+          sleep 2
         end
 
       parameters = {

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -140,7 +140,10 @@ class Channel < ApplicationRecord
 
     entries =
       if mode == :only_new
-        feed.entries.reject { self.items.exists?(guid: _1.entry_id) }
+        feed.entries.reject {
+          self.items.exists?(guid: _1.entry_id) ||
+          self.items.exists?(guid: _1.url)
+        }
       else
         feed.entries
       end

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -135,17 +135,20 @@ class Channel < ApplicationRecord
     end
   end
 
-  def fetch_and_save_items(mode = :only_new)
+  def fetch_and_save_items(mode = :only_recent)
     feed = Feedjira.parse(Httpc.get(feed_url))
 
     entries =
-      if mode == :only_new
+      if mode == :all
+        feed.entries
+      elsif mode == :only_non_existing
         feed.entries.reject {
           self.items.exists?(guid: _1.entry_id) ||
           self.items.exists?(guid: _1.url)
         }
       else
-        feed.entries
+        # only_recent
+        feed.entries.sort_by(&:published).reverse.take(20)
       end
 
     entries.sort_by(&:published).each do |entry|

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -152,7 +152,6 @@ class Channel < ApplicationRecord
       end
 
     entries.sort_by(&:published).each do |entry|
-      p ["Fetching", entry.published, entry.title, entry.url]
       next if entry.title.blank?
 
       url = (entry.url || self.site_url).strip
@@ -188,7 +187,10 @@ class Channel < ApplicationRecord
         published_at: entry.published,
         data: entry.to_h,
       }
-      self.items.find_or_initialize_by(guid: guid).update(parameters)
+      item = self.items.find_or_initialize_by(guid: guid)
+      p ["Saving item", item.title, item.url, item.published_at] if item.new_record?
+
+      item.update(parameters)
     end
   end
 


### PR DESCRIPTION
- Itemのtitle等が更新されていたら追随したい
- Itemの情報取得ループに sleep を入れていたが、フィードに記載されている情報のみを参照する場合は sleep しなくてよい