### PR TITLE
ChannelItemsUpdaterJob が詰まっちゃう問題をなんとかする

### DIFF
--- a/app/controllers/channels/fetch_controller.rb
+++ b/app/controllers/channels/fetch_controller.rb
@@ -4,7 +4,7 @@ class Channels::FetchController < ApplicationController
   def create
     channel = Channel.find(params[:channel_id])
     Channel.add(channel.feed_url)
-    ChannelItemsUpdaterJob.perform_later(channel_id: channel.id)
+    ChannelItemsUpdaterJob.perform_later(channel_id: channel.id, mode: :only_recent)
     DiscoPosterJob.perform_later(content: "@#{current_user.name} requested to update #{channel.title}")
 
     redirect_to channel, notice: "Channel updated, and fetching items in the background."

--- a/app/jobs/channel_items_updater_job.rb
+++ b/app/jobs/channel_items_updater_job.rb
@@ -1,5 +1,5 @@
 class ChannelItemsUpdaterJob < ApplicationJob
-  def perform(channel_id:, mode: :only_recent)
+  def perform(channel_id:, mode: :only_non_existing)
     channel = Channel.find(channel_id)
     channel.fetch_and_save_items(mode)
   end

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -135,7 +135,7 @@ class Channel < ApplicationRecord
     end
   end
 
-  def fetch_and_save_items(mode = :only_recent)
+  def fetch_and_save_items(mode = :only_non_existing)
     feed = Feedjira.parse(Httpc.get(feed_url))
 
     entries =
@@ -148,7 +148,7 @@ class Channel < ApplicationRecord
         }
       else
         # only_recent
-        feed.entries.sort_by(&:published).reverse.take(20)
+        feed.entries.sort_by(&:published).reverse.take(10)
       end
 
     entries.sort_by(&:published).each do |entry|


### PR DESCRIPTION
- https://github.com/kairan-app/feeeed/pull/274

の変更をやってみたら、ジョブキューに ChannelItemsUpdaterJob がどんどんたまるようになってしまった :innocent:

「Item の情報に変更があったら、検知して取り込みたい」と思ったものの、それを実現しようとすると新着 Item 更新処理の所要時間が長くなってしまうようだった。あれこれ工夫したいところだけど、まずは変更前の処理内容に近づけて、ジョブキューが詰まらないようにする :dash:
