### PR TITLE
Solid Queue v0.9.0 から、設定ファイルの名前は queue.yml に変わったのだった

### DIFF
--- a/config/queue.yml
+++ b/config/queue.yml
@@ -4,8 +4,8 @@ default: &default
       batch_size: 500
   workers:
     - queues: [ default ]
-      threads: 2
-      processes: <%= ENV.fetch("JOB_CONCURRENCY", 2) %>
+      threads: 3
+      processes: <%= ENV.fetch("JOB_CONCURRENCY", 3) %>
       polling_interval: 1
     - queues: [ disco ]
       threads: 1


### PR DESCRIPTION
な〜んか solid_queue.yml の内容が反映されていない気がする、と思ったら、それもそのはず。

- https://github.com/kairan-app/feeeed/pull/271

を見たときに「へぇ、設定ファイルの名前が変わったのか〜」とは認識していたのに自分のアプリケーションで追随できていなかった。悲しい。でもまた少し Solid Queue と仲良くなれた感触もあって、それはうれしい。