### PR TITLE
Item の guid を url で代用している場合にも新着通知できるように

### DIFF
--- a/app/jobs/item_creation_notifier_job.rb
+++ b/app/jobs/item_creation_notifier_job.rb
@@ -13,9 +13,10 @@ class ItemCreationNotifierJob < ApplicationJob
   end
 
   def should_notify?(item)
+    sleep 1
     # 新しい方から見て2件以内のItemのみ通知する
     feed = Feedjira.parse(Httpc.get(item.channel.feed_url))
-    return true if item.guid.in?(feed.entries.sort_by(&:published).reverse.take(2).map(&:entry_id))
+    return true if item.guid.in?(feed.entries.sort_by(&:published).reverse.take(2).map { [_1.entry_id, _1.url] }.flatten)
 
     false
   end

--- a/app/jobs/item_creation_notifier_job.rb
+++ b/app/jobs/item_creation_notifier_job.rb
@@ -13,7 +13,7 @@ class ItemCreationNotifierJob < ApplicationJob
   end
 
   def should_notify?(item)
-    # 新しい方から見て3件以内のItemのみ通知する
+    # 新しい方から見て2件以内のItemのみ通知する
     feed = Feedjira.parse(Httpc.get(item.channel.feed_url))
     return true if item.guid.in?(feed.entries.sort_by(&:published).reverse.take(2).map(&:entry_id))
 


### PR DESCRIPTION
ItemCreationNotifierJob の不備を見つけたので修正する :wrench:

- コメントと実装が合っていなかったので整える
- Item の guid を url で代用しているフィードの場合、新着を Discord に通知する処理が意図した通りに動いていないと気付いたので直す
- 新着判定のときはフィードに HTTP でアクセスするので、連続でアクセスしすぎないように sleep を入れる
  - Channel モデルにフィードの内容をキャッシュするようにしてもいいかもなあ、と思った
