### PR TITLE
ActiveRecord の enum の書き方が変わったのであった

### DIFF
--- a/app/models/notification_email.rb
+++ b/app/models/notification_email.rb
@@ -11,7 +11,7 @@ class NotificationEmail < ApplicationRecord
 
   scope :only_verified, -> { where.not(verified_at: nil) }
 
-  enum mode: {
+  enum :mode, {
     my_subscribed_items: 0,
     my_pawprints: 1,
   }

--- a/app/models/notification_webhook.rb
+++ b/app/models/notification_webhook.rb
@@ -7,7 +7,7 @@ class NotificationWebhook < ApplicationRecord
   validates :url, presence: true, length: { maximum: 2083 }, format: { with: URI.regexp }
   validates :mode, presence: true
 
-  enum mode: {
+  enum :mode, {
     my_subscribed_items: 0,
     my_pawprints: 1,
   }


### PR DESCRIPTION
Rails 8 にしたら動かなくなっちゃったね、直します :wrench:
