### PR TITLE
全モデルの URL 系カラムの validation を共通化する

### DIFF
--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -4,6 +4,7 @@ class Channel < ApplicationRecord
   include EmptyStringsAreAlignedToNil
   include ValidationErrorsNotifiable
   include UrlHttpValidator
+
   has_many :items, dependent: :destroy
   has_many :ownerships, dependent: :destroy
   has_many :owners, through: :ownerships, source: :user

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -3,7 +3,7 @@ class Channel < ApplicationRecord
   include Stripable
   include EmptyStringsAreAlignedToNil
   include ValidationErrorsNotifiable
-
+  include UrlHttpValidator
   has_many :items, dependent: :destroy
   has_many :ownerships, dependent: :destroy
   has_many :owners, through: :ownerships, source: :user
@@ -15,9 +15,8 @@ class Channel < ApplicationRecord
 
   validates :title, presence: true, length: { maximum: 256 }
   validates :description, length: { maximum: 1024 }
-  validates :site_url, length: { maximum: 2083 }
-  validates :feed_url, presence: true, length: { maximum: 2083 }, uniqueness: true
-  validates :image_url, length: { maximum: 2083 }
+  validates :feed_url, presence: true
+  validates_url_http_format_of :feed_url, :site_url, :image_url
 
   strip_before_save :title, :description
   empty_strings_are_aligned_to_nil :description, :site_url, :image_url

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -16,7 +16,7 @@ class Channel < ApplicationRecord
 
   validates :title, presence: true, length: { maximum: 256 }
   validates :description, length: { maximum: 1024 }
-  validates :feed_url, presence: true
+  validates :feed_url, presence: true, uniqueness: true
   validates_url_http_format_of :feed_url, :site_url, :image_url
 
   strip_before_save :title, :description

--- a/app/models/channel_group_webhook.rb
+++ b/app/models/channel_group_webhook.rb
@@ -1,12 +1,14 @@
 class ChannelGroupWebhook < ApplicationRecord
   include SlackBlockBuilder
+  include UrlHttpValidator
 
   belongs_to :user
   belongs_to :channel_group
 
   validates :user_id, presence: true
   validates :channel_group_id, presence: true
-  validates :url, presence: true, length: { maximum: 2083 }, format: { with: URI.regexp }
+  validates :url, presence: true
+  validates_url_http_format_of :url
 
   class << self
     def notify

--- a/app/models/concerns/url_http_validator.rb
+++ b/app/models/concerns/url_http_validator.rb
@@ -1,0 +1,18 @@
+module UrlHttpValidator
+  extend ActiveSupport::Concern
+
+  included do
+    class_attribute :url_http_validatable_columns
+  end
+
+  class_methods do
+    def validates_url_http_format_of(*columns)
+      self.url_http_validatable_columns = columns
+      columns.each do |column|
+        validates column,
+          format: { with: URI.regexp(%w[http https]), message: "is not a valid URL" },
+          length: { maximum: 2083 }
+      end
+    end
+  end
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,6 +2,7 @@ class Item < ApplicationRecord
   include Stripable
   include EmptyStringsAreAlignedToNil
   include ValidationErrorsNotifiable
+  include UrlHttpValidator
 
   belongs_to :channel
   has_many :pawprints, dependent: :destroy
@@ -10,9 +11,9 @@ class Item < ApplicationRecord
   validates :channel_id, presence: true
   validates :guid, presence: true, length: { maximum: 2083 }, uniqueness: { scope: :channel_id }
   validates :title, presence: true, length: { maximum: 256 }
-  validates :url, presence: true, length: { maximum: 2083 }
-  validates :image_url, length: { maximum: 2083 }, format: { with: URI::regexp(%w[http https]), message: "must be a valid URL" }
+  validates :url, presence: true
   validates :published_at, presence: true
+  validates_url_http_format_of :url, :image_url
 
   strip_before_save :title
   empty_strings_are_aligned_to_nil :image_url

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -11,7 +11,7 @@ class Item < ApplicationRecord
   validates :guid, presence: true, length: { maximum: 2083 }, uniqueness: { scope: :channel_id }
   validates :title, presence: true, length: { maximum: 256 }
   validates :url, presence: true, length: { maximum: 2083 }
-  validates :image_url, length: { maximum: 2083 }
+  validates :image_url, length: { maximum: 2083 }, format: { with: URI::regexp(%w[http https]), message: "must be a valid URL" }
   validates :published_at, presence: true
 
   strip_before_save :title

--- a/app/models/notification_webhook.rb
+++ b/app/models/notification_webhook.rb
@@ -1,11 +1,13 @@
 class NotificationWebhook < ApplicationRecord
   include SlackBlockBuilder
+  include UrlHttpValidator
 
   belongs_to :user
 
   validates :user_id, presence: true
-  validates :url, presence: true, length: { maximum: 2083 }, format: { with: URI.regexp }
+  validates :url, presence: true
   validates :mode, presence: true
+  validates_url_http_format_of :url
 
   enum :mode, {
     my_subscribed_items: 0,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  include UrlHttpValidator
+
   has_many :ownerships, dependent: :destroy
   has_many :owned_channels, through: :ownerships, source: :channel
   has_many :memberships, dependent: :destroy
@@ -16,7 +18,8 @@ class User < ApplicationRecord
 
   validates :name, presence: true, uniqueness: true, length: { in: 2..30 }
   validates :email, presence: true, length: { maximum: 254 }
-  validates :icon_url, presence: true, length: { maximum: 2083 }
+  validates :icon_url, presence: true
+  validates_url_http_format_of :icon_url
 
   def username_changed?
     email.split('@').first != name


### PR DESCRIPTION
### あらすじ

とある Item の image_url に URL としては invalid な文字列が保存されてしまい、ActionView::Template::Error が発生するに至った。

```
ActionView::Template::Error: The asset "【template_SNSサムネイル】" is not present in the asset pipeline. (ActionView::Template::Error)
```
https://feeeed.sentry.io/issues/6106414770/

### ここでやること

URL 系のカラムにへんな文字列が保存されてしまわないように、まじめに validation をやるぞ！
