### PR TITLE
load_defaults を 8.0 にする

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -9,7 +9,7 @@ Bundler.require(*Rails.groups)
 module Feeeed
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 7.1
+    config.load_defaults 8.0
 
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.


### PR DESCRIPTION
- https://github.com/kairan-app/feeeed/pull/323

にて Rails 8 系になったのはよかったけれど load_defaults が 7.1 を指していた (7.2 ですらなかった！) ので、気付いたこのタイミングでアゲアゲに上げます :up:
