### PR TITLE
UrlHttpValidatorにて、nilはオッケーとする

### DIFF
--- a/app/models/concerns/url_http_validator.rb
+++ b/app/models/concerns/url_http_validator.rb
@@ -11,7 +11,8 @@ module UrlHttpValidator
       columns.each do |column|
         validates column,
           format: { with: URI.regexp(%w[http https]), message: "is not a valid URL" },
-          length: { maximum: 2083 }
+          length: { maximum: 2083 },
+          allow_nil: true
       end
     end
   end


### PR DESCRIPTION
- https://github.com/kairan-app/feeeed/pull/337

で導入したロジックに意図しない挙動があり、image_urlがnilになるようなItemは保存できなくなっていました :sob:

UrlHttpValidatorではnilを許容して、nilにしたくないカラムについては別途で `presence: true` なvalidatesを記述してもらうのがよいでしょう。ってことで修正です :bow::dash:
