### PR TITLE
テキストフィールドをテキストエリアに変えて、長い文章を扱いやすくする

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -96,7 +96,7 @@ a:hover {
   z-index: -1;
 }
 
-#channel-registration-form:checked ~ .channel-registration-form-wrap {
+#channel-registration-form:checked~.channel-registration-form-wrap {
   transform: translateY(0%);
   opacity: 1;
   transition: 0.2s;
@@ -111,7 +111,7 @@ a:hover {
   display: none;
 }
 
-#channel-registration-form:checked ~ .channel-registration-form-wrap-bg {
+#channel-registration-form:checked~.channel-registration-form-wrap-bg {
   position: fixed;
   top: 0;
   left: -20px;
@@ -167,16 +167,12 @@ a:hover {
   transform-origin: 0%;
 }
 
-#channel-registration-form:checked
-  ~ .channel-registration-form-button
-  .channel-registration-form-button-mark:nth-of-type(1) {
+#channel-registration-form:checked~.channel-registration-form-button .channel-registration-form-button-mark:nth-of-type(1) {
   transform: translate(3px, -3px) rotate(45deg);
   transform-origin: 0%;
 }
 
-#channel-registration-form:checked
-  ~ .channel-registration-form-button
-  .channel-registration-form-button-mark:nth-of-type(2) {
+#channel-registration-form:checked~.channel-registration-form-button .channel-registration-form-button-mark:nth-of-type(2) {
   transform: translate(3px, 2px) rotate(-45deg);
   transform-origin: 0%;
 }
@@ -296,7 +292,7 @@ header nav ul li a:hover {
   }
 }
 
-#hamburger:checked ~ .hamburger-menu-list {
+#hamburger:checked~.hamburger-menu-list {
   transform: translateY(0%);
   transition: 0s;
   z-index: 2;
@@ -321,7 +317,7 @@ header nav ul li a:hover {
   display: none;
 }
 
-#hamburger:checked ~ .hamburger-menu-bg {
+#hamburger:checked~.hamburger-menu-bg {
   position: fixed;
   top: 0;
   left: -20px;
@@ -371,22 +367,16 @@ header nav ul li a:hover {
   transition: 0.3s;
 }
 
-#hamburger:checked
-  ~ .hamburger-menu-button
-  .hamburger-menu-button-mark:nth-of-type(1) {
+#hamburger:checked~.hamburger-menu-button .hamburger-menu-button-mark:nth-of-type(1) {
   transform: translate(3px, -1px) rotate(45deg);
   transform-origin: 0%;
 }
 
-#hamburger:checked
-  ~ .hamburger-menu-button
-  .hamburger-menu-button-mark:nth-of-type(2) {
+#hamburger:checked~.hamburger-menu-button .hamburger-menu-button-mark:nth-of-type(2) {
   opacity: 0;
 }
 
-#hamburger:checked
-  ~ .hamburger-menu-button
-  .hamburger-menu-button-mark:nth-of-type(3) {
+#hamburger:checked~.hamburger-menu-button .hamburger-menu-button-mark:nth-of-type(3) {
   transform: translate(3px, 1px) rotate(-45deg);
   transform-origin: 0%;
 }
@@ -987,6 +977,7 @@ a.remove-from-my-own:hover {
 }
 
 @media screen and (max-width: 768px) {
+
   .setting-mode,
   .setting-url-or-email {
     width: 100%;
@@ -1180,7 +1171,7 @@ a.remove-from-my-own:hover {
 .unreads-list {
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
+  align-items: baseline;
   border-top: 0.5px solid #dddddd;
 }
 
@@ -1618,6 +1609,7 @@ a.remove-from-my-own:hover {
 }
 
 @media screen and (max-width: 768px) {
+
   .about-contents,
   .info-contents {
     width: 100%;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -14,6 +14,10 @@
  *= require_self
  */
 
+textarea {
+  field-sizing: content;
+}
+
 .br-sp {
   display: none;
 }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1171,7 +1171,7 @@ a.remove-from-my-own:hover {
 .unreads-list {
   display: flex;
   flex-wrap: wrap;
-  align-items: baseline;
+  align-items: top;
   border-top: 0.5px solid #dddddd;
 }
 

--- a/app/views/items/_pawprint.html.erb
+++ b/app/views/items/_pawprint.html.erb
@@ -1,16 +1,6 @@
 <% if logged_in? %>
   <%= turbo_frame_tag(id_of_pawprint_form_for(item)) do %>
     <% pawprint = item.pawprints.find_by(user: current_user) %>
-
-    <%= form_tag(item_pawprint_path(item), method: :post) do %>
-      <%= text_area_tag(:memo, pawprint&.memo, placeholder: "Memo", style: "width: calc(100% - 58px); padding: 4px 8px;") %>
-      <%= submit_tag("Paw!", class: "p-1 border border-slate-500 rounded-sm bg-slate-100 hover:bg-slate-200 cursor-pointer") %>
-    <% end %>
-
-    <% if pawprint %>
-      <p class="button-to-unpaw">
-        <%= link_to("Unpaw!", item_pawprint_path(item), data: { turbo_method: :delete }) %>
-      </p>
-    <% end %>
+    <%= render(partial: "items/pawprint_form", locals: { item: item, pawprint: pawprint }) %>
   <% end %>
 <% end %>

--- a/app/views/items/_pawprint.html.erb
+++ b/app/views/items/_pawprint.html.erb
@@ -3,7 +3,7 @@
     <% pawprint = item.pawprints.find_by(user: current_user) %>
 
     <%= form_tag(item_pawprint_path(item), method: :post) do %>
-      <%= text_field_tag(:memo, pawprint&.memo, placeholder: "Memo", style: "width: calc(100% - 58px); padding: 4px 8px;") %>
+      <%= text_area_tag(:memo, pawprint&.memo, placeholder: "Memo", style: "width: calc(100% - 58px); padding: 4px 8px;") %>
       <%= submit_tag("Paw!", class: "p-1 border border-slate-500 rounded-sm bg-slate-100 hover:bg-slate-200 cursor-pointer") %>
     <% end %>
 

--- a/app/views/items/_pawprint_form.html.erb
+++ b/app/views/items/_pawprint_form.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag(id_of_pawprint_form_for(item)) do %>
   <%= form_tag(item_pawprint_path(item), method: :post) do %>
     <%= hidden_field_tag(:form_mode, "pawprint_form") %>
-    <%= text_field_tag(:memo, pawprint&.memo, placeholder: "Memo", style: "width: calc(100% - 41px); padding: 4px 8px;") %>
+    <%= text_area_tag(:memo, pawprint&.memo, placeholder: "Memo", style: "width: calc(100% - 41px); padding: 4px 8px;") %>
     <% image_file_name = pawprint ? "paw-on.png" : "paw-off.png" %>
     <%= image_submit_tag(image_file_name, width: "36px", height: "36px", style: "vertical-align: top;") %>
   <% end %>


### PR DESCRIPTION
### 発端

- https://github.com/kairan-app/feeeed/issues/361 by @taizooo

### このPRでやること

- Pawprintのフォームのテキストフィールドをテキストエリアに変えて、表示上で複数行に渡るような長さの文字列も全容が表示されるようにする
- 際して、表示が崩れないように調整を行う
