### PR TITLE
Docker Composeに頼らず、Pumaのpluginでtailwindcss:watchする

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -36,6 +36,8 @@ plugin :tmp_restart
 # Run the Solid Queue supervisor inside of Puma for single-server deployments
 plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"]
 
+plugin :tailwindcss if ENV.fetch("RAILS_ENV", "development") == "development"
+
 # Specify the PID file. Defaults to tmp/pids/server.pid in development.
 # In other environments, only set the PID file if requested.
 pidfile ENV["PIDFILE"] if ENV["PIDFILE"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,11 +25,5 @@ services:
     depends_on:
       - database
     command: bin/jobs
-  tailwindcss:
-    build: .
-    volumes:
-      - .:/app
-      - bundle:/usr/local/bundle
-    command: bin/rails tailwindcss:watch[always]
 volumes:
   bundle:


### PR DESCRIPTION
https://github.com/rails/tailwindcss-rails?tab=readme-ov-file#puma-plugin にて案内されているものを使う。

そうすることで、Docker ComposeのServiceがひとつ減るのでリソースの削減になると期待している。記述量が少し減るってのも少しうれしいね。
