### PR TITLE
Pawprintのフォームを整理して、どこからでもPaw/Unpawをできるようにする

### DIFF
--- a/app/controllers/pawprints_controller.rb
+++ b/app/controllers/pawprints_controller.rb
@@ -9,12 +9,10 @@ class PawprintsController < ApplicationController
   end
 
   def create
-    @form_mode = params[:form_mode]
     @pawprint = current_user.paw(@item, memo: params[:memo])
   end
 
   def destroy
-    @form_mode = params[:form_mode]
     current_user.unpaw(@item)
   end
 

--- a/app/controllers/pawprints_controller.rb
+++ b/app/controllers/pawprints_controller.rb
@@ -13,6 +13,7 @@ class PawprintsController < ApplicationController
   end
 
   def destroy
+    @prev_memo = params[:memo]
     current_user.unpaw(@item)
   end
 

--- a/app/views/items/_pawprint.html.erb
+++ b/app/views/items/_pawprint.html.erb
@@ -1,4 +1,10 @@
 <% if logged_in? %>
 <% pawprint = item.pawprints.find_by(user: current_user) %>
-<%= render(partial: "items/pawprint_form", locals: { item: item, pawprint: pawprint }) %>
+<%= turbo_frame_tag(id_of_pawprint_form_for(item)) do %>
+  <%= form_tag(item_pawprint_path(item), method: :post) do %>
+    <%= text_area_tag(:memo, pawprint&.memo, placeholder: "Memo", style: "width: calc(100% - 41px); padding: 4px 8px;") %>
+    <% image_file_name = pawprint ? "paw-on.png" : "paw-off.png" %>
+    <%= image_submit_tag(image_file_name, width: "36px", height: "36px", style: "vertical-align: top;") %>
+  <% end %>
+<% end %>
 <% end %>

--- a/app/views/items/_pawprint.html.erb
+++ b/app/views/items/_pawprint.html.erb
@@ -1,6 +1,4 @@
 <% if logged_in? %>
-  <%= turbo_frame_tag(id_of_pawprint_form_for(item)) do %>
-    <% pawprint = item.pawprints.find_by(user: current_user) %>
-    <%= render(partial: "items/pawprint_form", locals: { item: item, pawprint: pawprint }) %>
-  <% end %>
+<% pawprint = item.pawprints.find_by(user: current_user) %>
+<%= render(partial: "items/pawprint_form", locals: { item: item, pawprint: pawprint }) %>
 <% end %>

--- a/app/views/items/_pawprint.html.erb
+++ b/app/views/items/_pawprint.html.erb
@@ -1,10 +1,17 @@
 <% if logged_in? %>
-<% pawprint = item.pawprints.find_by(user: current_user) %>
-<%= turbo_frame_tag(id_of_pawprint_form_for(item)) do %>
-  <%= form_tag(item_pawprint_path(item), method: :post) do %>
-    <%= text_area_tag(:memo, pawprint&.memo, placeholder: "Memo", style: "width: calc(100% - 41px); padding: 4px 8px;") %>
-    <% image_file_name = pawprint ? "paw-on.png" : "paw-off.png" %>
-    <%= image_submit_tag(image_file_name, width: "36px", height: "36px", style: "vertical-align: top;") %>
+  <% pawprint = item.pawprints.find_by(user: current_user) %>
+  <% memo = pawprint&.memo || @prev_memo %>
+  <%= turbo_frame_tag(id_of_pawprint_form_for(item)) do %>
+    <% if pawprint %>
+      <%= form_tag(item_pawprint_path(item), method: :delete) do %>
+        <%= text_area_tag(:memo, memo, placeholder: "Memo", style: "width: calc(100% - 41px); padding: 4px 8px;") %>
+        <%= image_submit_tag("paw-on.png", width: "36px", height: "36px", style: "vertical-align: top;") %>
+      <% end %>
+    <% else %>
+      <%= form_tag(item_pawprint_path(item), method: :post) do %>
+        <%= text_area_tag(:memo, memo, placeholder: "Memo", style: "width: calc(100% - 41px); padding: 4px 8px;") %>
+        <%= image_submit_tag("paw-off.png", width: "36px", height: "36px", style: "vertical-align: top;") %>
+      <% end %>
+    <% end %>
   <% end %>
-<% end %>
 <% end %>

--- a/app/views/items/_pawprint_form.html.erb
+++ b/app/views/items/_pawprint_form.html.erb
@@ -1,6 +1,5 @@
 <%= turbo_frame_tag(id_of_pawprint_form_for(item)) do %>
   <%= form_tag(item_pawprint_path(item), method: :post) do %>
-    <%= hidden_field_tag(:form_mode, "pawprint_form") %>
     <%= text_area_tag(:memo, pawprint&.memo, placeholder: "Memo", style: "width: calc(100% - 41px); padding: 4px 8px;") %>
     <% image_file_name = pawprint ? "paw-on.png" : "paw-off.png" %>
     <%= image_submit_tag(image_file_name, width: "36px", height: "36px", style: "vertical-align: top;") %>

--- a/app/views/items/_pawprint_form.html.erb
+++ b/app/views/items/_pawprint_form.html.erb
@@ -1,7 +1,0 @@
-<%= turbo_frame_tag(id_of_pawprint_form_for(item)) do %>
-  <%= form_tag(item_pawprint_path(item), method: :post) do %>
-    <%= text_area_tag(:memo, pawprint&.memo, placeholder: "Memo", style: "width: calc(100% - 41px); padding: 4px 8px;") %>
-    <% image_file_name = pawprint ? "paw-on.png" : "paw-off.png" %>
-    <%= image_submit_tag(image_file_name, width: "36px", height: "36px", style: "vertical-align: top;") %>
-  <% end %>
-<% end %>

--- a/app/views/my/unreads/show.html.erb
+++ b/app/views/my/unreads/show.html.erb
@@ -57,7 +57,7 @@
                 <%= link_to("Skip", item_skip_path(item), data: { turbo_method: :post }) %>
               </div>
               <div class="channel-and-items-component-item-memo">
-                <%= render(partial: "items/pawprint_form", locals: { item: item, pawprint: nil }) %>
+                <%= render(partial: "items/pawprint", locals: { item: item, pawprint: nil }) %>
               </div>
             </div>
           </div>

--- a/app/views/pawprints/_blocks.html.erb
+++ b/app/views/pawprints/_blocks.html.erb
@@ -31,7 +31,7 @@
           <span class="ml-1">pawed on <%= pawprint.created_at.strftime("%Y-%m-%d %H:%M") %></span>
         </div>
         <% if user == current_user %>
-          <%= render(partial: "items/pawprint_form", locals: { item: item, pawprint: pawprint }) %>
+          <%= render(partial: "items/pawprint", locals: { item: item, pawprint: pawprint }) %>
         <% else %>
           <% if pawprint.memo.present? %>
           <div class="pawprint-memo"><%= pawprint.memo %></div>
@@ -43,7 +43,7 @@
                 <%= link_to("@" + current_user.name, user_path(user_name: current_user.name)) %>
               </div>
               <div class="chase-paw-form">
-                <%= render(partial: "items/pawprint_form", locals: { item: item, pawprint: nil }) %>
+                <%= render(partial: "items/pawprint", locals: { item: item, pawprint: nil }) %>
               </div>
             </div>
           <% end %>

--- a/app/views/pawprints/_lines.html.erb
+++ b/app/views/pawprints/_lines.html.erb
@@ -31,7 +31,7 @@
           <span>pawed on <%= pawprint.created_at.strftime("%Y-%m-%d %H:%M") %></span>
         </div>
         <% if user == current_user%>
-          <%= render(partial: "items/pawprint_form", locals: { item: item, pawprint: pawprint }) %>
+          <%= render(partial: "items/pawprint", locals: { item: item, pawprint: pawprint }) %>
         <% else %>
           <% if pawprint.memo.present? %>
           <div class="pawprint-memo"><%= pawprint.memo %></div>
@@ -43,7 +43,7 @@
                 <%= link_to("@" + current_user.name, user_path(user_name: current_user.name)) %>
               </div>
               <div class="chase-paw-form">
-                <%= render(partial: "items/pawprint_form", locals: { item: item, pawprint: nil }) %>
+                <%= render(partial: "items/pawprint", locals: { item: item, pawprint: nil }) %>
               </div>
             </div>
           <% end %>

--- a/app/views/pawprints/create.turbo_stream.erb
+++ b/app/views/pawprints/create.turbo_stream.erb
@@ -1,7 +1,3 @@
 <%= turbo_stream.replace(id_of_pawprint_form_for(@item)) do %>
-  <% if @form_mode == "pawprint_form" %>
-    <%= render(partial: "items/pawprint_form", locals: { item: @item, pawprint: @pawprint }) %>
-  <% else %>
-    <%= render(partial: "items/pawprint", locals: { item: @item }) %>
-  <% end %>
+  <%= render(partial: "items/pawprint_form", locals: { item: @item, pawprint: @pawprint }) %>
 <% end %>

--- a/app/views/pawprints/create.turbo_stream.erb
+++ b/app/views/pawprints/create.turbo_stream.erb
@@ -1,3 +1,3 @@
 <%= turbo_stream.replace(id_of_pawprint_form_for(@item)) do %>
-  <%= render(partial: "items/pawprint_form", locals: { item: @item, pawprint: @pawprint }) %>
+  <%= render(partial: "items/pawprint", locals: { item: @item, pawprint: @pawprint }) %>
 <% end %>

--- a/app/views/pawprints/destroy.turbo_stream.erb
+++ b/app/views/pawprints/destroy.turbo_stream.erb
@@ -1,3 +1,3 @@
 <%= turbo_stream.replace(id_of_pawprint_form_for(@item)) do %>
-  <%= render(partial: "items/pawprint_form", locals: { item: @item }) %>
+  <%= render(partial: "items/pawprint", locals: { item: @item }) %>
 <% end %>

--- a/app/views/pawprints/destroy.turbo_stream.erb
+++ b/app/views/pawprints/destroy.turbo_stream.erb
@@ -1,7 +1,3 @@
 <%= turbo_stream.replace(id_of_pawprint_form_for(@item)) do %>
-  <% if @form_mode == "pawprint_form" %>
-    <%= render(partial: "items/pawprint_form", locals: { item: @item }) %>
-  <% else %>
-    <%= render(partial: "items/pawprint", locals: { item: @item }) %>
-  <% end %>
+  <%= render(partial: "items/pawprint_form", locals: { item: @item }) %>
 <% end %>


### PR DESCRIPTION
### あらすじ

- https://github.com/kairan-app/feeeed/issues/366

### やること

- 一時期、Pawprintのフォームは2種類あって、そのための分岐も存在していた
  - 今は1種類になったけれどコードベースには2種類あった時期の残骸が残っていたので一通り整理する
- PawしたらUnpaw用のフォームが表示されるようにして、利用者からはトグルっぽく見えるようにする
  - このとき、もともとMemoに書いていた内容は保持されるように工夫する
