### PR TITLE
新規Channel登録の処理を改善する / Feedbag.findする前にFeedjira.parseしちゃう

### DIFF
--- a/app/controllers/channels/preview_controller.rb
+++ b/app/controllers/channels/preview_controller.rb
@@ -3,7 +3,12 @@ class Channels::PreviewController < ApplicationController
 
   def show
     url = params[:url]
-    @channel = Channel.preview(url)
+    begin
+      @channel = Channel.preview(url)
+    rescue Feedjira::NoParserAvailable
+      return redirect_to(root_path, alert: "Can't find feed from '#{url}'")
+    end
+
     return redirect_to(root_path, alert: "Can't find feed from '#{url}'") if @channel.nil?
 
     @similar_channels = Channel.similar_to(@channel)

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -39,18 +39,37 @@ class Channel < ApplicationRecord
     end
 
     def add(url)
-      feed_url = Feedbag.find(url).first
+      feed = nil
+      feed_url = nil
 
+      begin
+        feed = Feedjira.parse(Httpc.get(url))
+        feed_url = url
+      rescue Feedjira::NoParserAvailable
+        feed_url = Feedbag.find(url).first
+        feed = Feedjira.parse(Httpc.get(feed_url)) if feed_url
+      end
+
+      return nil if feed.nil?
       return nil if feed_url.nil?
-
       save_from(feed_url)
     end
 
     def preview(url)
-      feed_url = Feedbag.find(url).first
+      feed = nil
+      feed_url = nil
+
+      begin
+        feed = Feedjira.parse(Httpc.get(url))
+        feed_url = url
+      rescue Feedjira::NoParserAvailable
+        feed_url = Feedbag.find(url).first
+        feed = Feedjira.parse(Httpc.get(feed_url)) if feed_url
+      end
+
+      return nil if feed.nil?
       return nil if feed_url.nil?
 
-      feed = Feedjira.parse(Httpc.get(feed_url))
       feed.url = feed.url.strip if feed.url
 
       parameters =


### PR DESCRIPTION
### 問題意識

- https://github.com/kairan-app/feeeed/issues/362

にて報告をいただいているように、Validなフィードがありながらそれを登録しようとするとうまくいかないケースが散見されています。Channel登録処理を見直して、ひとつでも多くのフィードをChannelとして保存できるようにします :muscle:

### 今回やること

これまでは下記のように処理していました。

- `Feedbag.find(url)` してフィードのURLを探す
- 発見できたら、それを `Channel.add(feed_url)` に渡す

ですが、これだとうまく扱えないケースがあるってことがわかってきました。なので下記のように変えます。

- URLが与えられたら
  - まずは `Feedjira.parse(url)` してみて、パース成功したらそのURLをフィードのURLとして扱う
    - URLとしてValidなフィードのURLが与えられた場合は、これでうまくいく
  - パース失敗したら `Feedbag.find(url)` であらためてフィードのURLを探してからパースを試す
    - フィードじゃなくてサイトのURLを与えられた場合は、これで処理する

これで、今まで追加できていたパターンはそのままに、追加できなかったうちのいくつかは追加できるようになるはず :muscle:
