### PR TITLE
ChannelページとChannelGroupページはnoindexにする

### DIFF
--- a/app/controllers/channel_groups_controller.rb
+++ b/app/controllers/channel_groups_controller.rb
@@ -12,6 +12,7 @@ class ChannelGroupsController < ApplicationController
     @channel_group = ChannelGroup.find(params[:id])
     @channels = @channel_group.channels.order("channel_groupings.id DESC")
     @items = @channel_group.items.order(published_at: :desc, title: :desc).limit(48)
+    @noindex = true
 
     @title = @channel_group.name
   end

--- a/app/controllers/channels_controller.rb
+++ b/app/controllers/channels_controller.rb
@@ -13,6 +13,7 @@ class ChannelsController < ApplicationController
     page = (params[:page].presence || 1).to_i
     @channel = Channel.find(params[:channel_id])
     @items = @channel.items.preload(:pawprints).order(published_at: :desc, title: :desc).page(page).per(48)
+    @noindex = true
 
     @title = @channel.title
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <% if @noindex %>
+    <meta name="robots" content="noindex">
+    <% end %>
     <%= favicon_link_tag "square.png" %>
     <link rel="stylesheet" href="https://unpkg.com/modern-css-reset/dist/reset.min.css" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,300,0,0" />


### PR DESCRIPTION
いま、Googleにけっこうインデックスされていて「謎の情報集約サイト」のような印象を持たれがちになっています。われわれとしては「フィードリーダ」のつもりで、たまたま「Channelページ」がどんどん生成されて検索流入も生み出しているけれど、そこでページビューを増やしたいとも思っていないので、ためしにnoindexにしてみます :v:

@sugiwe さんとは合意済みです :muscle:
