### PR TITLE
og:imageに画像の相対URLが入っているとItemの保存にしちゃうので、絶対URLに変換してみる

### DIFF
--- a/app/controllers/channels/preview_controller.rb
+++ b/app/controllers/channels/preview_controller.rb
@@ -2,7 +2,7 @@ class Channels::PreviewController < ApplicationController
   before_action :login_required
 
   def show
-    url = params[:url]
+    url = params[:url].to_s.strip
     begin
       @channel = Channel.preview(url)
     rescue Feedjira::NoParserAvailable

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -198,9 +198,6 @@ class Channel < ApplicationRecord
           OpenGraph.new(encoded_url).image rescue nil
         end
 
-      # og:imageに相対URLが指定されている場合は、site_urlを基準に絶対URLに変換する
-      image_url = URI.join(site_url, image_url).to_s if image_url&.start_with?("/")
-
       parameters = {
         guid: guid,
         title: entry.title,

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -198,6 +198,9 @@ class Channel < ApplicationRecord
           OpenGraph.new(encoded_url).image rescue nil
         end
 
+      # og:imageに相対URLが指定されている場合は、site_urlを基準に絶対URLに変換する
+      image_url = URI.join(site_url, image_url).to_s if image_url&.start_with?("/")
+
       parameters = {
         guid: guid,
         title: entry.title,

--- a/lib/open_graph.rb
+++ b/lib/open_graph.rb
@@ -15,5 +15,8 @@ class OpenGraph
     metas = @html.css("meta")
     @description = metas.find { |m| m.attributes.find { |a| a[1].value == "og:description" } }&.attributes&.dig("content")&.value
     @image = metas.find { |m| m.attributes.find { |a| a[1].value == "og:image" } }&.attributes&.dig("content")&.value
+
+    # og:imageに相対URLが指定されている場合は、@urlを基準に絶対URLに変換する
+    @image = URI.join(@url, @image).to_s if @image&.start_with?("/")
   end
 end


### PR DESCRIPTION
タイトルの通りです。これによって保存に失敗しているItemがいくつかあります。

The Open Graph protocol https://ogp.me/ としてog:imageに相対URLを入れることをどう扱っているかは理解しきれていないため、今回の対応が妥当かどうかは自信ナシ。どこかにタイミングで対応方針を変えることもあるかも！
