### PR TITLE
NotificationWebhookの初回通知の処理を改善する

### DIFF
--- a/app/models/notification_webhook.rb
+++ b/app/models/notification_webhook.rb
@@ -38,7 +38,11 @@ class NotificationWebhook < ApplicationRecord
   def notify_pawprints_to_discord(since: nil)
     at = since || default_since_time
     pawprints = user.pawprints.where("created_at >= ?", at).order(:id)
-    return if pawprints.empty?
+
+    if pawprints.empty?
+      touch(:last_notified_at)
+      return
+    end
 
     DiscoPosterJob.perform_later(content:
       "NotificationWebhook performed (id: #{id}, user: @#{user.name}, mode: pawprints_to_discord, #{pawprints.count} pawprints)"
@@ -60,7 +64,11 @@ class NotificationWebhook < ApplicationRecord
   def notify_pawprints_to_slack(since: nil)
     at = since || default_since_time
     pawprints = user.pawprints.where("created_at >= ?", at).order(:id)
-    return if pawprints.empty?
+
+    if pawprints.empty?
+      touch(:last_notified_at)
+      return
+    end
 
     DiscoPosterJob.perform_later(content:
       "NotificationWebhook performed (id: #{id}, user: @#{user.name}, mode: pawprints_to_slack, #{pawprints.count} pawprints)"
@@ -88,7 +96,11 @@ class NotificationWebhook < ApplicationRecord
   def notify_subscribed_items_to_discord(since: nil)
     at = since || default_since_time
     items = user.subscribed_items.where("items.created_at >= ?", at).order("items.id")
-    return if items.empty?
+
+    if items.empty?
+      touch(:last_notified_at)
+      return
+    end
 
     DiscoPosterJob.perform_later(content:
       "NotificationWebhook performed (id: #{id}, user: @#{user.name}, mode: subscribed_items_to_discord, #{items.count} items)"
@@ -111,7 +123,11 @@ class NotificationWebhook < ApplicationRecord
   def notify_subscribed_items_to_slack(since: nil)
     at = since || default_since_time
     items = user.subscribed_items.preload(:channel).where("items.created_at >= ?", at)
-    return if items.empty?
+
+    if items.empty?
+      touch(:last_notified_at)
+      return
+    end
 
     DiscoPosterJob.perform_later(content:
       "NotificationWebhook performed (id: #{id}, user: @#{user.name}, mode: subscribed_items_to_slack, #{items.count} items)"

--- a/app/models/notification_webhook.rb
+++ b/app/models/notification_webhook.rb
@@ -20,6 +20,10 @@ class NotificationWebhook < ApplicationRecord
     end
   end
 
+  def default_since_time
+    last_notified_at || 24.hours.ago
+  end
+
   def notify
     is_slack = URI(url).host == "hooks.slack.com"
 
@@ -32,7 +36,7 @@ class NotificationWebhook < ApplicationRecord
   end
 
   def notify_pawprints_to_discord(since: nil)
-    at = since || last_notified_at || 6.hours.ago
+    at = since || default_since_time
     pawprints = user.pawprints.where("created_at >= ?", at).order(:id)
     return if pawprints.empty?
 
@@ -54,7 +58,7 @@ class NotificationWebhook < ApplicationRecord
   end
 
   def notify_pawprints_to_slack(since: nil)
-    at = since || last_notified_at || 6.hours.ago
+    at = since || default_since_time
     pawprints = user.pawprints.where("created_at >= ?", at).order(:id)
     return if pawprints.empty?
 
@@ -82,7 +86,7 @@ class NotificationWebhook < ApplicationRecord
   end
 
   def notify_subscribed_items_to_discord(since: nil)
-    at = since || last_notified_at || 6.hours.ago
+    at = since || default_since_time
     items = user.subscribed_items.where("items.created_at >= ?", at).order("items.id")
     return if items.empty?
 
@@ -105,7 +109,7 @@ class NotificationWebhook < ApplicationRecord
   end
 
   def notify_subscribed_items_to_slack(since: nil)
-    at = since || last_notified_at || 6.hours.ago
+    at = since || default_since_time
     items = user.subscribed_items.preload(:channel).where("items.created_at >= ?", at)
     return if items.empty?
 


### PR DESCRIPTION
### 問題意識

これまで、NotificationWebhookのnotify系のメソッドは

- last_notified_atがnilのときは「6時間以内のPawprint/Item」を対象とする
- 通知するPawprint/Itemが0個だった場合はlast_notified_atを更新しない

となっていた。これで問題ないと思っていたのだけれど、

- 毎日00:00にnotifyを行う
- 18:00以降はアプリケーションを利用しない、というスタイルの人がいる

のふたつが組み合わさると「last_notified_atがnil」で「直近6時間以内のPawprintはない」という状況が続いてしまい、一向に通知が行われなくなってしまう。

### 対応

- 直近6時間以内 → 直近24時間以内
- 通知するPawprint/Itemが0個だったときもlast_notified_atを更新する
