### PR TITLE
Channelの新着Itemチェック処理にて、Channel情報も更新する

### DIFF
--- a/app/controllers/channels/fetch_controller.rb
+++ b/app/controllers/channels/fetch_controller.rb
@@ -3,7 +3,6 @@ class Channels::FetchController < ApplicationController
 
   def create
     channel = Channel.find(params[:channel_id])
-    Channel.add(channel.feed_url)
     ChannelItemsUpdaterJob.perform_later(channel_id: channel.id, mode: :only_recent)
     DiscoPosterJob.perform_later(content: "@#{current_user.name} requested to update #{channel.title}")
 

--- a/app/jobs/channel_items_updater_job.rb
+++ b/app/jobs/channel_items_updater_job.rb
@@ -1,6 +1,7 @@
 class ChannelItemsUpdaterJob < ApplicationJob
   def perform(channel_id:, mode: :only_non_existing)
     channel = Channel.find(channel_id)
+    Channel.save_from(channel.feed_url)
     channel.fetch_and_save_items(mode)
   end
 end

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -72,17 +72,7 @@ class Channel < ApplicationRecord
 
       feed.url = feed.url.strip if feed.url
 
-      parameters =
-        case feed
-        when Feedjira::Parser::RSS
-          build_from_rss(feed)
-        when Feedjira::Parser::Atom
-          build_from_atom(feed)
-        when Feedjira::Parser::ITunesRSS
-          build_from_itunes_rss(feed)
-        when Feedjira::Parser::AtomYoutube
-          build_from_atom_youtube(feed)
-        end
+      parameters = build_from(feed)
 
       Channel.new(parameters.merge(feed_url: feed_url))
     end
@@ -91,21 +81,24 @@ class Channel < ApplicationRecord
       feed = Feedjira.parse(Httpc.get(feed_url))
       feed.url = feed.url.strip if feed.url
 
-      parameters =
-        case feed
-        when Feedjira::Parser::RSS
-          build_from_rss(feed)
-        when Feedjira::Parser::Atom
-          build_from_atom(feed)
-        when Feedjira::Parser::ITunesRSS
-          build_from_itunes_rss(feed)
-        when Feedjira::Parser::AtomYoutube
-          build_from_atom_youtube(feed)
-        end
+      parameters = build_from(feed)
 
       channel = Channel.find_or_initialize_by(feed_url: feed_url)
       channel.update(parameters)
       channel
+    end
+
+    def build_from(feed)
+      case feed
+      when Feedjira::Parser::RSS
+        build_from_rss(feed)
+      when Feedjira::Parser::Atom
+        build_from_atom(feed)
+      when Feedjira::Parser::ITunesRSS
+        build_from_itunes_rss(feed)
+      when Feedjira::Parser::AtomYoutube
+        build_from_atom_youtube(feed)
+      end
     end
 
     def build_from_rss(feed)


### PR DESCRIPTION
現状においても `POST /channels/:channel_id/fetch` すればChannelのメタデータ(サムネイル画像や概要文など)を更新できるけど、

https://github.com/kairan-app/feeeed/blob/a2b7289fb35ae76dd2236d422b2b0fb72e34fee7/config/routes.rb#L18-L19

定期的に実行されているChannelItemsUpdaterJobの中で更新を行うようにすれば自動更新されるね、ってことでそうしてみます。
