### PR TITLE
ChannelとItemの画像、見切れることなく表示できるとうれしいのであれこれ試す

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -511,6 +511,11 @@ header nav ul li a:hover {
   aspect-ratio: 1 / 1;
 }
 
+.item-card .card-image {
+  aspect-ratio: 3 / 2;
+}
+
+/* Channel card image styles */
 .channel-card-image-background,
 .channel-card-image-foreground {
   position: absolute;
@@ -540,6 +545,41 @@ header nav ul li a:hover {
 }
 
 .channel-card-image-foreground img {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+}
+
+/* Item card image styles */
+.item-card-image-background,
+.item-card-image-foreground {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.item-card-image-background {
+  z-index: 1;
+}
+
+.item-card-image-background img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: blur(10px);
+  transform: scale(1.1);
+}
+
+.item-card-image-foreground {
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.item-card-image-foreground img {
   max-width: 100%;
   max-height: 100%;
   object-fit: contain;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -526,6 +526,7 @@ header nav ul li a:hover {
   background-position: center;
   background-size: cover;
   background-repeat: no-repeat;
+  overflow: hidden;
 }
 
 .channel-card-image::before {
@@ -1290,6 +1291,7 @@ a.remove-from-my-own:hover {
   background-position: center;
   background-size: cover;
   background-repeat: no-repeat;
+  overflow: hidden;
 }
 
 .component-item-image::before {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -497,14 +497,52 @@ header nav ul li a:hover {
   position: relative;
   width: 100%;
   line-height: 0;
+  overflow: hidden;
+}
+
+.card-image a {
+  position: relative;
+  display: block;
+  width: 100%;
+  height: 100%;
 }
 
 .channel-card .card-image {
   aspect-ratio: 1 / 1;
 }
 
-.item-card .card-image {
-  aspect-ratio: 3 / 2;
+.channel-card-image-background,
+.channel-card-image-foreground {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.channel-card-image-background {
+  z-index: 1;
+}
+
+.channel-card-image-background img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: blur(10px);
+  transform: scale(1.1);
+}
+
+.channel-card-image-foreground {
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.channel-card-image-foreground img {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
 }
 
 @media screen and (max-width: 768px) {
@@ -735,15 +773,45 @@ img {
 }
 
 .channel-profile-image {
+  position: relative;
   width: 240px;
   height: 240px;
   margin-right: 30px;
+  overflow: hidden;
+}
 
-  img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-  }
+.channel-profile-image-background,
+.channel-profile-image-foreground {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.channel-profile-image-background {
+  z-index: 1;
+}
+
+.channel-profile-image-background img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: blur(10px);
+  transform: scale(1.1);
+}
+
+.channel-profile-image-foreground {
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.channel-profile-image-foreground img {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
 }
 
 @media screen and (max-width: 768px) {
@@ -751,12 +819,6 @@ img {
     width: 240px;
     height: 240px;
     margin: 0 auto 20px;
-
-    img {
-      width: 100%;
-      height: 100%;
-      object-fit: cover;
-    }
   }
 }
 

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1210,36 +1210,26 @@ a.remove-from-my-own:hover {
 
 .channel-and-items-component-channel a {
   display: flex;
-  flex-wrap: wrap;
-  justify-content: left;
   align-items: center;
-  height: 84px;
+  gap: 10px;
   padding: 10px;
   transition: 0.25s;
-
-  img {
-    width: 64px;
-    height: 64px;
-    object-fit: cover;
-    margin-right: 10px;
-    outline: solid 1px #eeeeee;
-  }
-
-  span {
-    display: inline-block;
-    width: calc(100% - 74px);
-  }
 }
 
-@media screen and (max-width: 768px) {
-  .channel-and-items-component-channel a {
-    padding: 10px 0;
-  }
+.channel-and-items-component-channel a span {
+  flex: 1;
 }
 
-.channel-and-items-component-channel a:hover {
-  text-decoration: none;
-  background-color: rgba(255, 255, 255, 0.75);
+/* Channel component image styles */
+.channel-component-image {
+  position: relative;
+  height: 64px;
+  overflow: hidden;
+}
+
+.channel-component-image img {
+  height: 100%;
+  object-fit: contain;
 }
 
 .channel-and-items-component-item-list {
@@ -1287,16 +1277,45 @@ a.remove-from-my-own:hover {
 }
 
 .channel-and-items-component-item-image {
+  position: relative;
   width: 96px;
   height: 64px;
   margin: 0 10px 0 0;
+  overflow: hidden;
+}
 
-  img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    outline: solid 1px #eeeeee;
-  }
+.item-component-image-background,
+.item-component-image-foreground {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.item-component-image-background {
+  z-index: 1;
+}
+
+.item-component-image-background img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: blur(10px);
+  transform: scale(1.1);
+}
+
+.item-component-image-foreground {
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.item-component-image-foreground img {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
 }
 
 @media screen and (max-width: 1200px) {
@@ -1906,4 +1925,39 @@ a.remove-from-my-own:hover {
 
 .guides-button .material-symbols-outlined {
   font-size: 18px;
+}
+
+/* Item component image styles */
+.item-component-image-background,
+.item-component-image-foreground {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.item-component-image-background {
+  z-index: 1;
+}
+
+.item-component-image-background img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: blur(10px);
+  transform: scale(1.1);
+}
+
+.item-component-image-foreground {
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.item-component-image-foreground img {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
 }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -500,13 +500,6 @@ header nav ul li a:hover {
   overflow: hidden;
 }
 
-.card-image a {
-  position: relative;
-  display: block;
-  width: 100%;
-  height: 100%;
-}
-
 .channel-card .card-image {
   aspect-ratio: 1 / 1;
 }
@@ -1211,6 +1204,11 @@ a.remove-from-my-own:hover {
   gap: 10px;
   padding: 10px;
   transition: 0.25s;
+}
+
+.channel-and-items-component-channel a:hover {
+  text-decoration: none;
+  background-color: rgba(255, 255, 255, 0.75);
 }
 
 .channel-and-items-component-channel a span {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -516,70 +516,68 @@ header nav ul li a:hover {
 }
 
 /* Channel card image styles */
-.channel-card-image-background,
-.channel-card-image-foreground {
+.channel-card-image {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-position: center;
+  background-size: cover;
+  background-repeat: no-repeat;
+}
+
+.channel-card-image::before {
+  content: '';
   position: absolute;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
-}
-
-.channel-card-image-background {
+  background: inherit;
+  filter: blur(10px);
+  transform: scale(1.1);
   z-index: 1;
 }
 
-.channel-card-image-background img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  filter: blur(10px);
-  transform: scale(1.1);
-}
-
-.channel-card-image-foreground {
+.channel-card-image img {
+  position: relative;
   z-index: 2;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.channel-card-image-foreground img {
   max-width: 100%;
   max-height: 100%;
   object-fit: contain;
 }
 
 /* Item card image styles */
-.item-card-image-background,
-.item-card-image-foreground {
+.item-card-image {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-position: center;
+  background-size: cover;
+  background-repeat: no-repeat;
+}
+
+.item-card-image::before {
+  content: '';
   position: absolute;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
-}
-
-.item-card-image-background {
+  background: inherit;
+  filter: blur(10px);
+  transform: scale(1.1);
   z-index: 1;
 }
 
-.item-card-image-background img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  filter: blur(10px);
-  transform: scale(1.1);
-}
-
-.item-card-image-foreground {
+.item-card-image img {
+  position: relative;
   z-index: 2;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.item-card-image-foreground img {
   max-width: 100%;
   max-height: 100%;
   object-fit: contain;
@@ -813,42 +811,40 @@ img {
 }
 
 .channel-profile-image {
-  position: relative;
   width: 240px;
   height: 240px;
   margin-right: 30px;
   overflow: hidden;
 }
 
-.channel-profile-image-background,
-.channel-profile-image-foreground {
+.channel-profile-image-container {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-position: center;
+  background-size: cover;
+  background-repeat: no-repeat;
+}
+
+.channel-profile-image-container::before {
+  content: '';
   position: absolute;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
-}
-
-.channel-profile-image-background {
+  background: inherit;
+  filter: blur(10px);
+  transform: scale(1.1);
   z-index: 1;
 }
 
-.channel-profile-image-background img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  filter: blur(10px);
-  transform: scale(1.1);
-}
-
-.channel-profile-image-foreground {
+.channel-profile-image-container img {
+  position: relative;
   z-index: 2;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.channel-profile-image-foreground img {
   max-width: 100%;
   max-height: 100%;
   object-fit: contain;
@@ -1284,40 +1280,40 @@ a.remove-from-my-own:hover {
   overflow: hidden;
 }
 
-.item-component-image-background,
-.item-component-image-foreground {
+.component-item-image {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-position: center;
+  background-size: cover;
+  background-repeat: no-repeat;
+}
+
+.component-item-image::before {
+  content: '';
   position: absolute;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
-}
-
-.item-component-image-background {
+  background: inherit;
+  filter: blur(10px);
+  transform: scale(1.1);
   z-index: 1;
 }
 
-.item-component-image-background img {
+.component-item-image img {
+  position: relative;
+  z-index: 2;
   width: 100%;
   height: 100%;
-  object-fit: cover;
-  filter: blur(10px);
-  transform: scale(1.1);
-}
-
-.item-component-image-foreground {
-  z-index: 2;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.item-component-image-foreground img {
-  max-width: 100%;
-  max-height: 100%;
   object-fit: contain;
 }
 
+/* Item component image styles */
 @media screen and (max-width: 1200px) {
   .channel-and-items-component-item-image {
     width: 96px;
@@ -1925,39 +1921,4 @@ a.remove-from-my-own:hover {
 
 .guides-button .material-symbols-outlined {
   font-size: 18px;
-}
-
-/* Item component image styles */
-.item-component-image-background,
-.item-component-image-foreground {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-}
-
-.item-component-image-background {
-  z-index: 1;
-}
-
-.item-component-image-background img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  filter: blur(10px);
-  transform: scale(1.1);
-}
-
-.item-component-image-foreground {
-  z-index: 2;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.item-component-image-foreground img {
-  max-width: 100%;
-  max-height: 100%;
-  object-fit: contain;
 }

--- a/app/views/channels/_flex_cards.html.erb
+++ b/app/views/channels/_flex_cards.html.erb
@@ -1,7 +1,14 @@
 <% channels.each do |channel| %>
 <div class="min-w-[160px] mr-[20px] sm:min-w-[240px]">
-  <div class="w-[160px] h-[160px] sm:w-[240px] sm:h-[240px]">
-    <%= link_to(image_tag(channel.image_url_or_placeholder, class: "w-full h-full object-cover"), channel) %>
+  <div class="relative w-[160px] h-[160px] sm:w-[240px] sm:h-[240px]">
+    <%= link_to channel do %>
+      <div class="channel-card-image-background">
+        <%= image_tag(channel.image_url_or_placeholder, class: "blurred") %>
+      </div>
+      <div class="channel-card-image-foreground">
+        <%= image_tag(channel.image_url_or_placeholder) %>
+      </div>
+    <% end %>
   </div>
   <h3 class="card-title">
     <%= image_tag(channel.favicon_url, size: "16x16") %>

--- a/app/views/channels/_flex_cards.html.erb
+++ b/app/views/channels/_flex_cards.html.erb
@@ -2,10 +2,7 @@
 <div class="min-w-[160px] mr-[20px] sm:min-w-[240px]">
   <div class="relative w-[160px] h-[160px] sm:w-[240px] sm:h-[240px]">
     <%= link_to channel do %>
-      <div class="channel-card-image-background">
-        <%= image_tag(channel.image_url_or_placeholder, class: "blurred") %>
-      </div>
-      <div class="channel-card-image-foreground">
+      <div class="channel-card-image" style="background-image: url('<%= channel.image_url_or_placeholder %>')">
         <%= image_tag(channel.image_url_or_placeholder) %>
       </div>
     <% end %>

--- a/app/views/channels/_grid_cards.html.erb
+++ b/app/views/channels/_grid_cards.html.erb
@@ -2,7 +2,14 @@
   <% channels.each do |channel| %>
   <div class="card channel-card">
     <div class="card-image">
-      <%= link_to(image_tag(channel.image_url_or_placeholder, class: "w-full h-full object-cover"), channel) %>
+      <%= link_to channel do %>
+        <div class="channel-card-image-background">
+          <%= image_tag(channel.image_url_or_placeholder, class: "blurred") %>
+        </div>
+        <div class="channel-card-image-foreground">
+          <%= image_tag(channel.image_url_or_placeholder) %>
+        </div>
+      <% end %>
     </div>
     <h3 class="card-title">
       <%= image_tag(channel.favicon_url, size: "16x16") %>

--- a/app/views/channels/_grid_cards.html.erb
+++ b/app/views/channels/_grid_cards.html.erb
@@ -3,10 +3,7 @@
   <div class="card channel-card">
     <div class="card-image">
       <%= link_to channel do %>
-        <div class="channel-card-image-background">
-          <%= image_tag(channel.image_url_or_placeholder, class: "blurred") %>
-        </div>
-        <div class="channel-card-image-foreground">
+        <div class="channel-card-image" style="background-image: url('<%= channel.image_url_or_placeholder %>')">
           <%= image_tag(channel.image_url_or_placeholder) %>
         </div>
       <% end %>

--- a/app/views/channels/_with3items.html.erb
+++ b/app/views/channels/_with3items.html.erb
@@ -2,7 +2,9 @@
   <h3 class="text-lg font-bold mt-2 channel-and-items-component-channel">
     <%= link_to channel_path(channel) do %>
       <% if channel.image_url %>
-      <%= image_tag(channel.image_url, size: "64x64",) %>
+        <div class="channel-component-image">
+          <%= image_tag(channel.image_url) %>
+        </div>
       <% end %>
       <span>
         <%= channel.title %>
@@ -15,7 +17,9 @@
       <li>
       <%= link_to(item.url, target: "_blank") do %>
         <div class="channel-and-items-component-item-image">
-          <%= image_tag(item.image_url_or_placeholder, width: "100%", height: "100%", style: "object-fit: cover;") %>
+          <div class="component-item-image" style="background-image: url('<%= item.image_url_or_placeholder %>')">
+            <%= image_tag(item.image_url_or_placeholder) %>
+          </div>
         </div>
         <div class="channel-and-items-component-item-info">
           <h4 class="font-bold">

--- a/app/views/channels/show.html.erb
+++ b/app/views/channels/show.html.erb
@@ -1,10 +1,7 @@
 <div class="channel-profile">
   <% if @channel.image_url %>
   <div class="channel-profile-image">
-    <div class="channel-profile-image-background">
-      <%= image_tag(@channel.image_url, class: "blurred") %>
-    </div>
-    <div class="channel-profile-image-foreground">
+    <div class="channel-profile-image-container" style="background-image: url('<%= @channel.image_url %>')">
       <%= image_tag(@channel.image_url) %>
     </div>
   </div>

--- a/app/views/channels/show.html.erb
+++ b/app/views/channels/show.html.erb
@@ -1,7 +1,12 @@
 <div class="channel-profile">
   <% if @channel.image_url %>
   <div class="channel-profile-image">
-    <%= image_tag(@channel.image_url, style: "max-height: 240px;") %>
+    <div class="channel-profile-image-background">
+      <%= image_tag(@channel.image_url, class: "blurred") %>
+    </div>
+    <div class="channel-profile-image-foreground">
+      <%= image_tag(@channel.image_url) %>
+    </div>
   </div>
   <% end %>
 

--- a/app/views/items/_cards.html.erb
+++ b/app/views/items/_cards.html.erb
@@ -3,10 +3,7 @@
   <div class="card item-card">
     <div class="card-image">
       <%= link_to item.url, target: "_blank" do %>
-        <div class="item-card-image-background">
-          <%= image_tag(item.image_url_or_placeholder, class: "blurred") %>
-        </div>
-        <div class="item-card-image-foreground">
+        <div class="item-card-image" style="background-image: url('<%= item.image_url_or_placeholder %>')">
           <%= image_tag(item.image_url_or_placeholder) %>
         </div>
       <% end %>

--- a/app/views/items/_cards.html.erb
+++ b/app/views/items/_cards.html.erb
@@ -2,7 +2,14 @@
   <% items.each do |item| %>
   <div class="card item-card">
     <div class="card-image">
-      <%= link_to(image_tag(item.image_url_or_placeholder, class: "w-full h-full object-cover"), item.url, target: "_blank") %>
+      <%= link_to item.url, target: "_blank" do %>
+        <div class="item-card-image-background">
+          <%= image_tag(item.image_url_or_placeholder, class: "blurred") %>
+        </div>
+        <div class="item-card-image-foreground">
+          <%= image_tag(item.image_url_or_placeholder) %>
+        </div>
+      <% end %>
       <% if item.audio_enclosure_url %>
         <div class="audio-player audio-player-on-the-image">
           <audio style="width: 100%;" src="<%= item.audio_enclosure_url %>" controls controlslist="nodownload"></audio>

--- a/app/views/my/unreads/show.html.erb
+++ b/app/views/my/unreads/show.html.erb
@@ -22,7 +22,9 @@
     <h3 class="text-lg font-bold mt-2 channel-and-items-component-channel">
       <%= link_to channel_path(channel) do %>
         <% if channel.image_url %>
-        <%= image_tag(channel.image_url, size: "64x64",) %>
+          <div class="channel-component-image">
+            <%= image_tag(channel.image_url) %>
+          </div>
         <% end %>
         <span>
           <%= channel.title %>
@@ -35,7 +37,12 @@
         <li class="unreads-list">
           <%= link_to(item.url, target: "_blank") do %>
             <div class="channel-and-items-component-item-image">
-              <%= image_tag(item.image_url_or_placeholder, width: "100%", height: "100%", style: "object-fit: cover;") %>
+              <div class="item-component-image-background">
+                <%= image_tag(item.image_url_or_placeholder, class: "blurred") %>
+              </div>
+              <div class="item-component-image-foreground">
+                <%= image_tag(item.image_url_or_placeholder) %>
+              </div>
             </div>
             <div class="channel-and-items-component-item-info channel-and-items-component-item-info-unreads">
               <h4 class="font-bold">

--- a/app/views/my/unreads/show.html.erb
+++ b/app/views/my/unreads/show.html.erb
@@ -37,11 +37,8 @@
         <li class="unreads-list">
           <%= link_to(item.url, target: "_blank") do %>
             <div class="channel-and-items-component-item-image">
-              <div class="item-component-image-background">
-                <%= image_tag(item.image_url_or_placeholder, class: "blurred") %>
-              </div>
-              <div class="item-component-image-foreground">
-                <%= image_tag(item.image_url_or_placeholder) %>
+              <div class="component-item-image" style="background-image: url('<%= item.image_url_or_placeholder %>')">
+                <%= image_tag(item.image_url_or_placeholder, style: "object-fit: contain;") %>
               </div>
             </div>
             <div class="channel-and-items-component-item-info channel-and-items-component-item-info-unreads">

--- a/app/views/pawprints/_blocks.html.erb
+++ b/app/views/pawprints/_blocks.html.erb
@@ -6,7 +6,9 @@
       <div class="flex flex-wrap w-full">
         <div class="w-[96px] h-[64px] mr-2">
           <%= link_to(item.url, target: "_blank") do %>
-            <%= image_tag(item.image_url_or_placeholder, height: "100", class: "w-full h-full object-cover") %>
+            <div class="component-item-image" style="background-image: url('<%= item.image_url_or_placeholder %>')">
+              <%= image_tag(item.image_url_or_placeholder) %>
+            </div>
           <% end %>
         </div>
         <div class="w-[calc(100%-106px)] -mt-0.75">

--- a/app/views/pawprints/_lines.html.erb
+++ b/app/views/pawprints/_lines.html.erb
@@ -6,7 +6,9 @@
       <div class="pawprint-item">
         <div class="pawprint-item-image">
           <%= link_to(item.url, target: "_blank") do %>
-            <%= image_tag(item.image_url_or_placeholder, height: "100") %>
+            <div class="component-item-image" style="background-image: url('<%= item.image_url_or_placeholder %>')">
+              <%= image_tag(item.image_url_or_placeholder) %>
+            </div>
           <% end %>
         </div>
         <div class="pawprint-item-text">

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -7,7 +7,7 @@
       "check_name": "LinkToHref",
       "message": "Potentially unsafe model attribute in `link_to` href",
       "file": "app/views/channels/show.html.erb",
-      "line": 21,
+      "line": 23,
       "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
       "code": "link_to(Channel.find(params[:channel_id]).site_url, Channel.find(params[:channel_id]).site_url, :target => \"_blank\")",
       "render_path": [
@@ -15,7 +15,7 @@
           "type": "controller",
           "class": "ChannelsController",
           "method": "show",
-          "line": 18,
+          "line": 19,
           "file": "app/controllers/channels_controller.rb",
           "rendered": {
             "name": "channels/show",
@@ -37,19 +37,19 @@
     {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 4,
-      "fingerprint": "8ccf91762dfb636896865a4c2eb94642e8a2ffe6efa68f9e1b8026d5653275ad",
+      "fingerprint": "b04d82875176f2ad1b82372fd47e0f71a8211c0536503543d357159d3dc763c7",
       "check_name": "LinkToHref",
       "message": "Potentially unsafe model attribute in `link_to` href",
       "file": "app/views/items/_cards.html.erb",
       "line": 5,
       "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
-      "code": "link_to(image_tag((Unresolved Model).new.image_url_or_placeholder, :class => \"w-full h-full object-cover\"), (Unresolved Model).new.url, :target => \"_blank\")",
+      "code": "link_to((Unresolved Model).new.url, :target => \"_blank\")",
       "render_path": [
         {
           "type": "controller",
           "class": "ChannelGroupsController",
           "method": "show",
-          "line": 17,
+          "line": 18,
           "file": "app/controllers/channel_groups_controller.rb",
           "rendered": {
             "name": "channel_groups/show",
@@ -85,7 +85,7 @@
       "check_name": "LinkToHref",
       "message": "Potentially unsafe model attribute in `link_to` href",
       "file": "app/views/items/_cards.html.erb",
-      "line": 12,
+      "line": 16,
       "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
       "code": "link_to((Unresolved Model).new.title, (Unresolved Model).new.url, :target => \"_blank\")",
       "render_path": [
@@ -93,7 +93,7 @@
           "type": "controller",
           "class": "ChannelGroupsController",
           "method": "show",
-          "line": 17,
+          "line": 18,
           "file": "app/controllers/channel_groups_controller.rb",
           "rendered": {
             "name": "channel_groups/show",
@@ -129,7 +129,7 @@
       "check_name": "LinkToHref",
       "message": "Potentially unsafe model attribute in `link_to` href",
       "file": "app/views/channels/show.html.erb",
-      "line": 23,
+      "line": 25,
       "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
       "code": "link_to(Channel.find(params[:channel_id]).feed_url, Channel.find(params[:channel_id]).feed_url, :target => \"_blank\")",
       "render_path": [
@@ -137,7 +137,7 @@
           "type": "controller",
           "class": "ChannelsController",
           "method": "show",
-          "line": 18,
+          "line": 19,
           "file": "app/controllers/channels_controller.rb",
           "rendered": {
             "name": "channels/show",


### PR DESCRIPTION
いま、アプリケーションの都合で指定した縦横比の領域にcoverするように画像を表示しているが、それだと縦横比が合わないときに上下か左右が切れてしまう。これをcontain式にして、ベターにできないか試します。

| Before | After |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/f8859bba-7892-47c9-a5b1-ff26e68d07fb) | ![after](https://github.com/user-attachments/assets/a6a86b0a-15fb-4be5-93de-ab4c5426d3c9) |
