### PR TITLE
フッターの微調整

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,20 +31,20 @@
     <footer class="sticky top-[100vh] w-full pt-8 pb-24 bg-[#3d8bcd] text-white text-center md:py-8">
     <!-- 一時的に全ページのメニューを設置 -->
     <ul class="flex flex-wrap justify-center items-center mb-4 space-x-8">
-      <li><%= link_to("About", about_path, class: "text-white hover:text-white") %></li>
-      <li><%= link_to("Channels", channels_path, class: "text-white hover:text-white") %></li>
-      <li><%= link_to("Items", items_path, class: "text-white hover:text-white") %></li>
-      <li><%= link_to("Channel Groups", channel_groups_path, class: "text-white hover:text-white") %></li>
+      <li class="mx-4"><%= link_to("About", about_path, class: "text-white hover:text-white") %></li>
+      <li class="mx-4"><%= link_to("Channels", channels_path, class: "text-white hover:text-white") %></li>
+      <li class="mx-4"><%= link_to("Items", items_path, class: "text-white hover:text-white") %></li>
+      <li class="mx-4"><%= link_to("Channel Groups", channel_groups_path, class: "text-white hover:text-white") %></li>
       <% if logged_in? %>
-      <li><%= link_to("Pawprints", pawprints_path, class: "text-white hover:text-white") %></li>
-      <li><%= link_to("Users", users_path, class: "text-white hover:text-white") %></li>
-      <li><%= link_to("Unreads", unreads_path, class: "text-white hover:text-white") %></li>
-      <li><%= link_to("Settings", my_path, class: "text-white hover:text-white") %></li>
+      <li class="mx-4"><%= link_to("Pawprints", pawprints_path, class: "text-white hover:text-white") %></li>
+      <li class="mx-4"><%= link_to("Users", users_path, class: "text-white hover:text-white") %></li>
+      <li class="mx-4"><%= link_to("Unreads", unreads_path, class: "text-white hover:text-white") %></li>
+      <li class="mx-4"><%= link_to("Settings", my_path, class: "text-white hover:text-white") %></li>
       <% end %>
     </ul>
     <ul class="flex flex-wrap justify-center items-center mb-4 space-x-8">
-      <li><%= link_to("Terms of Service", terms_path, class: "text-white hover:text-white") %></li>
-      <li><%= link_to("Privacy Policy", privacy_path, class: "text-white hover:text-white") %></li>
+      <li class="mx-4"><%= link_to("Terms of Service", terms_path, class: "text-white hover:text-white") %></li>
+      <li class="mx-4"><%= link_to("Privacy Policy", privacy_path, class: "text-white hover:text-white") %></li>
     </ul>
     <p>© rururu</p>
     </footer>


### PR DESCRIPTION
フッターのメニュー部分、tailwindのデフォルトスタイルがあたってmargin-rightだけ付いていたので、スマホで見たときにちょっとだけ中央揃えからずれて見えていた（以下の画像だとChannel Groupsの右側の余白が大きい）現象を修正しました🎨

![20250507a](https://github.com/user-attachments/assets/b2bf313e-f741-4018-b03a-0ec2e56afab9)