### PR TITLE
Channelごとに新着Itemチェックのインターバルを設定できるように

### DIFF
--- a/app/jobs/channel_interval_adjustment_job.rb
+++ b/app/jobs/channel_interval_adjustment_job.rb
@@ -1,0 +1,9 @@
+class ChannelIntervalAdjustmentJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    Rails.logger.info "Starting channel interval adjustment..."
+    updated_count = Channel.adjust_all_check_intervals
+    Rails.logger.info "Channel interval adjustment completed. Updated #{updated_count} channels."
+  end
+end

--- a/app/jobs/channel_items_updater_job.rb
+++ b/app/jobs/channel_items_updater_job.rb
@@ -3,5 +3,6 @@ class ChannelItemsUpdaterJob < ApplicationJob
     channel = Channel.find(channel_id)
     channel.update_info
     channel.fetch_and_save_items(mode)
+    channel.mark_items_checked!
   end
 end

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -27,7 +27,7 @@ class Channel < ApplicationRecord
   scope :not_stopped, -> { where.missing(:stopper) }
   scope :needs_check_now, -> {
     where(last_items_checked_at: nil)
-      .or(where('last_items_checked_at < NOW() - ((check_interval_hours || \' hours\')::interval - interval \'10 minutes\')'))
+      .or(where("last_items_checked_at < NOW() - ((check_interval_hours || ' hours')::interval - interval '10 minutes')"))
   }
   scope :by_check_priority, -> {
     order(:check_interval_hours, :last_items_checked_at)
@@ -306,22 +306,22 @@ class Channel < ApplicationRecord
 
   def set_check_interval!
     # 各期間内のアイテム数をカウント
-    items_1_week = items.where('published_at > ?', 1.week.ago).count
-    items_2_weeks = items.where('published_at > ?', 2.weeks.ago).count
-    items_1_month = items.where('published_at > ?', 1.month.ago).count
-    items_2_months = items.where('published_at > ?', 2.months.ago).count
+    items_1_week = items.where("published_at > ?", 1.week.ago).count
+    items_2_weeks = items.where("published_at > ?", 2.weeks.ago).count
+    items_1_month = items.where("published_at > ?", 1.month.ago).count
+    items_2_months = items.where("published_at > ?", 2.months.ago).count
 
     interval = if items_1_week >= 3
                  1   # 1時間毎
-               elsif items_2_weeks >= 2
+    elsif items_2_weeks >= 2
                  3   # 3時間毎
-               elsif items_1_month >= 2
+    elsif items_1_month >= 2
                  4   # 4時間毎
-               elsif items_2_months >= 1
+    elsif items_2_months >= 1
                  12  # 12時間毎
-               else
+    else
                  24  # 24時間毎（デフォルト）
-               end
+    end
 
     update!(check_interval_hours: interval)
   end

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -25,6 +25,13 @@ class Channel < ApplicationRecord
   after_create_commit { ChannelItemsUpdaterJob.perform_later(channel_id: self.id, mode: :all) }
 
   scope :not_stopped, -> { where.missing(:stopper) }
+  scope :needs_check_now, -> {
+    where(last_items_checked_at: nil)
+      .or(where('last_items_checked_at < NOW() - ((check_interval_hours || \' hours\')::interval - interval \'10 minutes\')'))
+  }
+  scope :by_check_priority, -> {
+    order(:check_interval_hours, :last_items_checked_at)
+  }
 
   class << self
     def ransackable_attributes(auth_object = nil)
@@ -36,8 +43,25 @@ class Channel < ApplicationRecord
     end
 
     def fetch_and_save_items
-      not_stopped.find_each { ChannelItemsUpdaterJob.perform_later(channel_id: _1.id) }
+      not_stopped.needs_check_now.by_check_priority.find_each do |channel|
+        ChannelItemsUpdaterJob.perform_later(channel_id: channel.id)
+      end
     end
+
+    def adjust_all_check_intervals
+      total = not_stopped.count
+      updated = 0
+
+      not_stopped.find_each do |channel|
+        channel.set_check_interval!
+        updated += 1
+        Rails.logger.info "Channel #{channel.id} interval adjusted to #{channel.check_interval_hours} hours"
+      end
+
+      Rails.logger.info "Auto-adjusted check intervals for #{updated}/#{total} channels"
+      updated
+    end
+
 
     def add(url)
       feed = nil
@@ -276,9 +300,40 @@ class Channel < ApplicationRecord
     }
   end
 
+  def mark_items_checked!
+    update!(last_items_checked_at: Time.current)
+  end
+
+  def set_check_interval!
+    # 各期間内のアイテム数をカウント
+    items_1_week = items.where('published_at > ?', 1.week.ago).count
+    items_2_weeks = items.where('published_at > ?', 2.weeks.ago).count
+    items_1_month = items.where('published_at > ?', 1.month.ago).count
+    items_2_months = items.where('published_at > ?', 2.months.ago).count
+
+    interval = if items_1_week >= 3
+                 1   # 1時間毎
+               elsif items_2_weeks >= 2
+                 3   # 3時間毎
+               elsif items_1_month >= 2
+                 4   # 4時間毎
+               elsif items_2_months >= 1
+                 12  # 12時間毎
+               else
+                 24  # 24時間毎（デフォルト）
+               end
+
+    update!(check_interval_hours: interval)
+  end
+
   def notify_channel_change
     prefix = previous_changes.key?(:id) ? "New channel created" : "Channel updated"
-    changed_fields = previous_changes.keys.map { |field| "# #{field}\n- [Old] #{previous_changes[field].first}\n- [New] #{previous_changes[field].last}" }
+
+    # check_interval_hoursとlast_items_checked_atの変更は通知しない
+    ignored_fields = %w[check_interval_hours last_items_checked_at]
+    relevant_changes = previous_changes.except(*ignored_fields)
+
+    changed_fields = relevant_changes.keys.map { |field| "# #{field}\n- [Old] #{relevant_changes[field].first}\n- [New] #{relevant_changes[field].last}" }
     return if changed_fields.empty?
 
     content = [

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -1,0 +1,3 @@
+channel_interval_adjustment:
+  class: ChannelIntervalAdjustmentJob
+  schedule: every day at 3am

--- a/db/migrate/20250701112401_add_check_interval_to_channels.rb
+++ b/db/migrate/20250701112401_add_check_interval_to_channels.rb
@@ -1,0 +1,9 @@
+class AddCheckIntervalToChannels < ActiveRecord::Migration[8.0]
+  def change
+    add_column :channels, :check_interval_hours, :integer, default: 1
+    add_column :channels, :last_items_checked_at, :datetime
+
+    add_index :channels, :last_items_checked_at
+    add_index :channels, :check_interval_hours
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_09_17_151846) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_01_112401) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension "pg_catalog.plpgsql"
 
   create_table "channel_group_webhooks", force: :cascade do |t|
     t.bigint "channel_group_id", null: false
@@ -59,7 +59,11 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_17_151846) do
     t.string "image_url", limit: 2083
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "check_interval_hours", default: 1
+    t.datetime "last_items_checked_at"
+    t.index ["check_interval_hours"], name: "index_channels_on_check_interval_hours"
     t.index ["feed_url"], name: "index_channels_on_feed_url", unique: true
+    t.index ["last_items_checked_at"], name: "index_channels_on_last_items_checked_at"
     t.index ["site_url"], name: "index_channels_on_site_url"
   end
 
@@ -85,6 +89,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_17_151846) do
     t.jsonb "data"
     t.index ["channel_id", "guid"], name: "index_items_on_channel_id_and_guid", unique: true
     t.index ["channel_id"], name: "index_items_on_channel_id"
+    t.index ["created_at", "channel_id"], name: "index_items_on_created_at_and_channel_id"
     t.index ["published_at"], name: "index_items_on_published_at"
   end
 
@@ -136,6 +141,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_17_151846) do
     t.string "memo", limit: 300
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["item_id", "user_id"], name: "index_pawprints_on_item_id_and_user_id"
     t.index ["item_id"], name: "index_pawprints_on_item_id"
     t.index ["user_id", "item_id"], name: "index_pawprints_on_user_id_and_item_id", unique: true
     t.index ["user_id"], name: "index_pawprints_on_user_id"


### PR DESCRIPTION
これまで、すべてのChannelを1時間ごとにチェックしてきたけれど、Channelが増えるほどにキューが大変になるのと、ほとんどのChannelにとってHourlyのチェックは贅沢なので、調整できるようにします :dash:

このあと、別のPull Requestで「このChannelは、水曜日の7:00に更新されることがほとんど」のようなケースに対応できるようにして、さらなる効率的な新着Itemチェックも模索したい考えがあります :bulb:
