### PR TITLE
Channelの更新インターバルの設定が終わったので、除外カラムを廃止する

### DIFF
--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -328,12 +328,7 @@ class Channel < ApplicationRecord
 
   def notify_channel_change
     prefix = previous_changes.key?(:id) ? "New channel created" : "Channel updated"
-
-    # check_interval_hoursとlast_items_checked_atの変更は通知しない
-    ignored_fields = %w[check_interval_hours last_items_checked_at]
-    relevant_changes = previous_changes.except(*ignored_fields)
-
-    changed_fields = relevant_changes.keys.map { |field| "# #{field}\n- [Old] #{relevant_changes[field].first}\n- [New] #{relevant_changes[field].last}" }
+    changed_fields = previous_changes.keys.map { |field| "# #{field}\n- [Old] #{previous_changes[field].first}\n- [New] #{previous_changes[field].last}" }
     return if changed_fields.empty?
 
     content = [


### PR DESCRIPTION
- https://github.com/kairan-app/feeeed/pull/451

にて、すべてのChannelに対して変更を加える処理を走らせるに当たり「このカラムの変更は無視して、Discord通知しない」という制御を入れた。この除外は役目を終えたのでコードをシンプルに戻す。

ところで、updated_atは無視リストに入れていなかったので、結局すべてのChannelの変更分がDiscord通知された :innocent: