### PR TITLE
Channel情報変更のDiscord通知について、last_items_checked_atとupdated_atの変更は無視する

### DIFF
--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -328,7 +328,11 @@ class Channel < ApplicationRecord
 
   def notify_channel_change
     prefix = previous_changes.key?(:id) ? "New channel created" : "Channel updated"
-    changed_fields = previous_changes.keys.map { |field| "# #{field}\n- [Old] #{previous_changes[field].first}\n- [New] #{previous_changes[field].last}" }
+    # last_items_checked_atとupdated_atの変更は無視する
+    ignored_fields = %w[last_items_checked_at updated_at created_at]
+    significant_changes = previous_changes.except(*ignored_fields)
+
+    changed_fields = significant_changes.keys.map { |field| "# #{field}\n- [Old] #{significant_changes[field].first}\n- [New] #{significant_changes[field].last}" }
     return if changed_fields.empty?
 
     content = [

--- a/test/models/channel_notification_test.rb
+++ b/test/models/channel_notification_test.rb
@@ -15,7 +15,6 @@ class ChannelNotificationTest < ActiveSupport::TestCase
   end
 
   test "notify_channel_change ignores last_items_checked_at changes" do
-    # 最初の作成通知をクリア
     clear_enqueued_jobs
 
     # last_items_checked_atのみを変更
@@ -26,7 +25,6 @@ class ChannelNotificationTest < ActiveSupport::TestCase
   end
 
   test "notify_channel_change ignores updated_at changes" do
-    # 最初の作成通知をクリア
     clear_enqueued_jobs
 
     # touch を使ってupdated_atのみを更新
@@ -37,7 +35,6 @@ class ChannelNotificationTest < ActiveSupport::TestCase
   end
 
   test "notify_channel_change sends notification for meaningful changes" do
-    # 最初の作成通知をクリア
     clear_enqueued_jobs
 
     # titleを変更
@@ -47,7 +44,6 @@ class ChannelNotificationTest < ActiveSupport::TestCase
   end
 
   test "notify_channel_change sends notification for description changes" do
-    # 最初の作成通知をクリア
     clear_enqueued_jobs
 
     # descriptionを変更
@@ -57,7 +53,6 @@ class ChannelNotificationTest < ActiveSupport::TestCase
   end
 
   test "notify_channel_change ignores combined changes with only ignored fields" do
-    # 最初の作成通知をクリア
     clear_enqueued_jobs
 
     # last_items_checked_atとupdated_atを同時に変更
@@ -71,7 +66,6 @@ class ChannelNotificationTest < ActiveSupport::TestCase
   end
 
   test "notify_channel_change sends notification when meaningful fields change with ignored fields" do
-    # 最初の作成通知をクリア
     clear_enqueued_jobs
 
     # titleとlast_items_checked_atを同時に変更

--- a/test/models/channel_notification_test.rb
+++ b/test/models/channel_notification_test.rb
@@ -1,0 +1,85 @@
+require "test_helper"
+
+class ChannelNotificationTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  setup do
+    # ActiveJobをテストアダプターに設定
+    ActiveJob::Base.queue_adapter = :test
+
+    @channel = Channel.create!(
+      title: "Test Channel",
+      feed_url: "https://example.com/feed.xml",
+      description: "Test Description"
+    )
+  end
+
+  test "notify_channel_change ignores last_items_checked_at changes" do
+    # 最初の作成通知をクリア
+    clear_enqueued_jobs
+
+    # last_items_checked_atのみを変更
+    @channel.update!(last_items_checked_at: Time.current)
+
+    # Discord通知ジョブが実行されないことを確認
+    assert_enqueued_jobs 0, only: DiscoPosterJob
+  end
+
+  test "notify_channel_change ignores updated_at changes" do
+    # 最初の作成通知をクリア
+    clear_enqueued_jobs
+
+    # touch を使ってupdated_atのみを更新
+    @channel.touch
+
+    # Discord通知ジョブが実行されないことを確認
+    assert_enqueued_jobs 0, only: DiscoPosterJob
+  end
+
+  test "notify_channel_change sends notification for meaningful changes" do
+    # 最初の作成通知をクリア
+    clear_enqueued_jobs
+
+    # titleを変更
+    assert_enqueued_jobs 1, only: DiscoPosterJob do
+      @channel.update!(title: "New Title")
+    end
+  end
+
+  test "notify_channel_change sends notification for description changes" do
+    # 最初の作成通知をクリア
+    clear_enqueued_jobs
+
+    # descriptionを変更
+    assert_enqueued_jobs 1, only: DiscoPosterJob do
+      @channel.update!(description: "New Description")
+    end
+  end
+
+  test "notify_channel_change ignores combined changes with only ignored fields" do
+    # 最初の作成通知をクリア
+    clear_enqueued_jobs
+
+    # last_items_checked_atとupdated_atを同時に変更
+    @channel.assign_attributes(
+      last_items_checked_at: Time.current
+    )
+    @channel.save!
+
+    # Discord通知ジョブが実行されないことを確認
+    assert_enqueued_jobs 0, only: DiscoPosterJob
+  end
+
+  test "notify_channel_change sends notification when meaningful fields change with ignored fields" do
+    # 最初の作成通知をクリア
+    clear_enqueued_jobs
+
+    # titleとlast_items_checked_atを同時に変更
+    assert_enqueued_jobs 1, only: DiscoPosterJob do
+      @channel.update!(
+        title: "New Title",
+        last_items_checked_at: Time.current
+      )
+    end
+  end
+end


### PR DESCRIPTION
- notify_channel_changeメソッドを修正し、last_items_checked_at、updated_at、created_atの変更を無視
- これらのフィールドのみが変更された場合はDiscord通知を送信しない
- 他の意味のあるフィールド（title、descriptionなど）が変更された場合は通知を送信
- テストを追加して動作を確認

🤖 Generated with [Claude Code](https://claude.ai/code)