### PR TITLE
Workerのメモリ使用量を削減するためSolid Queueの設定を調整

### DIFF
--- a/config/queue.yml
+++ b/config/queue.yml
@@ -1,11 +1,11 @@
 default: &default
   dispatchers:
     - polling_interval: 1
-      batch_size: 500
+      batch_size: 50
   workers:
     - queues: [ default ]
-      threads: 3
-      processes: <%= ENV.fetch("JOB_CONCURRENCY", 3) %>
+      threads: 2
+      processes: <%= ENV.fetch("JOB_CONCURRENCY", 2) %>
       polling_interval: 1
     - queues: [ disco ]
       threads: 1


### PR DESCRIPTION
- batch_size: 500 → 50 (一度に処理するジョブ数を削減)
- threads: 3 → 2 (スレッド数を削減)
- processes: 3 → 2 (プロセス数を削減)

これにより並行処理数が9から4に削減され、メモリ使用率170%超の問題を解決する