### PR TITLE
Channelの新着Itemチェック処理のエラーハンドリングをやる

### DIFF
--- a/app/jobs/channel_items_updater_job.rb
+++ b/app/jobs/channel_items_updater_job.rb
@@ -1,8 +1,38 @@
 class ChannelItemsUpdaterJob < ApplicationJob
   def perform(channel_id:, mode: :only_non_existing)
     channel = Channel.find(channel_id)
-    channel.update_info
-    channel.fetch_and_save_items(mode)
-    channel.mark_items_checked!
+
+    begin
+      channel.update_info
+    rescue StandardError => e
+      handle_error(e, channel, "Failed to update channel info")
+    end
+
+    begin
+      channel.fetch_and_save_items(mode)
+    rescue StandardError => e
+      handle_error(e, channel, "Failed to fetch and save items")
+    end
+
+    begin
+      channel.mark_items_checked!
+    rescue StandardError => e
+      handle_error(e, channel, "Failed to mark items checked")
+    end
+  end
+
+  private
+
+  def handle_error(error, channel, context)
+    # Sentryにエラーを送信（スタックトレース付き）
+    Sentry.capture_exception(error, extra: {
+      channel_id: channel.id,
+      channel_title: channel.title,
+      feed_url: channel.feed_url,
+      context: context
+    })
+
+    # コンパクトなログ出力
+    logger.error "[ChannelItemsUpdaterJob] #{context} - Channel: #{channel.id} (#{channel.title}) - Error: #{error.class.name}: #{error.message}"
   end
 end


### PR DESCRIPTION
いま、対象サイトにアクセスして400系だったり500系だったりするとログにスタックトレースがドカッと出て容量を食うので、もうちょっとコンパクトにロギングできるように一工夫を入れます :dash:
