### PR TITLE
Channel/Itemのプレイスホルダ画像のURLエンコード問題を修正する

### DIFF
--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -388,7 +388,7 @@ class Channel < ApplicationRecord
   end
 
   def image_url_or_placeholder
-    image_url.presence || "https://placehold.jp/30/cccccc/ffffff/300x300.png?text=#{CGI.escape(self.title)}"
+    image_url.presence || "https://placehold.jp/30/cccccc/ffffff/300x300.png?text=#{URI.encode_www_form_component(self.title)}"
   end
 
   def mark_items_checked!

--- a/app/models/channel_group.rb
+++ b/app/models/channel_group.rb
@@ -25,6 +25,6 @@ class ChannelGroup < ApplicationRecord
   end
 
   def placeholder_url
-    "https://placehold.jp/30/cccccc/ffffff/300x300.png?text=#{CGI.escape(name)}"
+    "https://placehold.jp/30/cccccc/ffffff/300x300.png?text=#{URI.encode_www_form_component(name)}"
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -30,7 +30,7 @@ class Item < ApplicationRecord
   end
 
   def image_url_or_placeholder
-    image_url.presence || "https://placehold.jp/30/cccccc/ffffff/270x180.png?text=#{CGI.escape(self.title)}"
+    image_url.presence || "https://placehold.jp/30/cccccc/ffffff/270x180.png?text=#{URI.encode_www_form_component(self.title)}"
   end
 
   def summary(length: 1000)


### PR DESCRIPTION
Channel/Item のプレイスホルダ画像のURLエンコード問題を修正しました。

## 変更内容

- Channel#image_url_or_placeholder でのtextパラメータをURLエンコード
- Item#image_url_or_placeholder でのtextパラメータをURLエンコード
- ChannelGroup#placeholder_url でのtextパラメータをURLエンコード

Fixes #486

Generated with [Claude Code](https://claude.ai/code)