### PR TITLE
URLを扱うカラムの長さ上限を2083から4096に上げる

### DIFF
--- a/app/models/concerns/url_http_validator.rb
+++ b/app/models/concerns/url_http_validator.rb
@@ -1,6 +1,8 @@
 module UrlHttpValidator
   extend ActiveSupport::Concern
 
+  URL_MAX_LENGTH = 4096
+
   included do
     class_attribute :url_http_validatable_columns
   end
@@ -11,7 +13,7 @@ module UrlHttpValidator
       columns.each do |column|
         validates column,
           format: { with: URI.regexp(%w[http https]), message: "is not a valid URL" },
-          length: { maximum: 2083 },
+          length: { maximum: URL_MAX_LENGTH },
           allow_nil: true
       end
     end

--- a/db/migrate/20251028062312_change_image_url_to_text_for_channels_and_items.rb
+++ b/db/migrate/20251028062312_change_image_url_to_text_for_channels_and_items.rb
@@ -1,0 +1,32 @@
+class ChangeImageUrlToTextForChannelsAndItems < ActiveRecord::Migration[8.0]
+  NEW_URL_LIMIT = 4096
+  OLD_URL_LIMIT = 2083
+
+  def up
+    change_column :channels, :feed_url, :string, limit: NEW_URL_LIMIT
+    change_column :channels, :site_url, :string, limit: NEW_URL_LIMIT
+    change_column :channels, :image_url, :string, limit: NEW_URL_LIMIT
+
+    change_column :items, :url, :string, limit: NEW_URL_LIMIT
+    change_column :items, :image_url, :string, limit: NEW_URL_LIMIT
+
+    change_column :users, :icon_url, :string, limit: NEW_URL_LIMIT
+
+    change_column :notification_webhooks, :url, :string, limit: NEW_URL_LIMIT
+    change_column :channel_group_webhooks, :url, :string, limit: NEW_URL_LIMIT
+  end
+
+  def down
+    change_column :channels, :feed_url, :string, limit: OLD_URL_LIMIT
+    change_column :channels, :site_url, :string, limit: OLD_URL_LIMIT
+    change_column :channels, :image_url, :string, limit: OLD_URL_LIMIT
+
+    change_column :items, :url, :string, limit: OLD_URL_LIMIT
+    change_column :items, :image_url, :string, limit: OLD_URL_LIMIT
+
+    change_column :users, :icon_url, :string, limit: OLD_URL_LIMIT
+
+    change_column :notification_webhooks, :url, :string, limit: OLD_URL_LIMIT
+    change_column :channel_group_webhooks, :url, :string, limit: OLD_URL_LIMIT
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_17_020215) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_28_062312) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -55,7 +55,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_17_020215) do
 
   create_table "channel_group_webhooks", force: :cascade do |t|
     t.bigint "channel_group_id", null: false
-    t.string "url", limit: 2083, null: false
+    t.string "url", limit: 4096, null: false
     t.datetime "last_notified_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -94,9 +94,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_17_020215) do
   create_table "channels", force: :cascade do |t|
     t.string "title", limit: 256, null: false
     t.string "description", limit: 1024
-    t.string "site_url", limit: 2083
-    t.string "feed_url", limit: 2083, null: false
-    t.string "image_url", limit: 2083
+    t.string "site_url", limit: 4096
+    t.string "feed_url", limit: 4096, null: false
+    t.string "image_url", limit: 4096
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "check_interval_hours", default: 1
@@ -124,8 +124,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_17_020215) do
     t.bigint "channel_id", null: false
     t.string "guid", limit: 2083, null: false
     t.string "title", limit: 256, null: false
-    t.string "url", limit: 2083, null: false
-    t.string "image_url", limit: 2083
+    t.string "url", limit: 4096, null: false
+    t.string "image_url", limit: 4096
     t.datetime "published_at", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -173,7 +173,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_17_020215) do
 
   create_table "notification_webhooks", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.string "url", limit: 2083, null: false
+    t.string "url", limit: 4096, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "last_notified_at"
@@ -338,7 +338,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_17_020215) do
   create_table "users", force: :cascade do |t|
     t.string "name", limit: 30, null: false
     t.string "email", limit: 254, null: false
-    t.string "icon_url", limit: 2083, null: false
+    t.string "icon_url", limit: 4096, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "google_guid", null: false


### PR DESCRIPTION
- Qiitaの記事の `og:image` には、2500文字くらいのURLがカジュアルに指定されているようだった
- そのことでQiitaのユーザのフィードを登録すると、Channelは保存できるがItemが保存されない状態だった
- あれこれ調べてみて、2025年においてはもっと長いURLを扱ってよさそうだったので上限を引き上げることにする
  - 2083ってのは、古のIEの上限
  - 4096ってのは、現在のSafariがアドレスバーに表示するURLの長さの上限

RFC 7230では、request-lineの長さとして8000程度に対応できると望ましいとされているので、将来的に4096からさらに引き上げることもあるかもしれない！

>Various ad hoc limitations on request-line length are found in    practice.  It is RECOMMENDED that all HTTP senders and recipients    support, at a minimum, request-line lengths of 8000 octets.
>https://datatracker.ietf.org/doc/html/rfc7230
