### PR TITLE
JoinRequest管理画面に、紐づくUserの情報も表示したい

### DIFF
--- a/app/models/join_request.rb
+++ b/app/models/join_request.rb
@@ -31,4 +31,8 @@ class JoinRequest < ApplicationRecord
   def pending?
     approved_at.nil?
   end
+
+  def user
+    User.find_by(email: email)
+  end
 end

--- a/app/views/admin/join_requests/index.html.erb
+++ b/app/views/admin/join_requests/index.html.erb
@@ -11,6 +11,7 @@
               <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Email</th>
               <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Icon</th>
               <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Comment</th>
+              <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Signed Up User</th>
               <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Requested at</th>
               <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
             </tr>
@@ -30,6 +31,16 @@
                 </td>
                 <td class="px-4 py-2">
                   <%= request.comment.presence || "-" %>
+                </td>
+                <td class="px-4 py-2 whitespace-nowrap text-sm">
+                  <% if request.user %>
+                    <div class="flex items-center space-x-2">
+                      <%= image_tag request.user.avatar_url(variant: :small), class: "h-6 w-6 rounded-full", alt: request.user.name %>
+                      <span class="text-green-600 font-medium"><%= request.user.name %></span>
+                    </div>
+                  <% else %>
+                    <span class="text-gray-400">Not signed up</span>
+                  <% end %>
                 </td>
                 <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-500">
                   <%= request.created_at.strftime("%Y-%m-%d %H:%M") %>
@@ -72,6 +83,7 @@
               <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Email</th>
               <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Icon</th>
               <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Comment</th>
+              <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Signed Up User</th>
               <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Approved By</th>
               <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Approved At</th>
             </tr>
@@ -91,6 +103,16 @@
                 </td>
                 <td class="px-4 py-2">
                   <%= request.comment.presence || "-" %>
+                </td>
+                <td class="px-4 py-2 whitespace-nowrap text-sm">
+                  <% if request.user.present? %>
+                    <div class="flex items-center space-x-2">
+                      <%= image_tag request.user.avatar_url(variant: :small), class: "h-6 w-6 rounded-full", alt: request.user.name %>
+                      <span class="text-green-600 font-medium"><%= request.user.name %></span>
+                    </div>
+                  <% else %>
+                    <span class="text-gray-400">Not signed up</span>
+                  <% end %>
                 </td>
                 <td class="px-4 py-2 whitespace-nowrap text-sm">
                   <%= request.approved_by&.name || "-" %>


### PR DESCRIPTION
JoinRequestをApproveしたときにメールでお知らせしているが、そのメールがSpam判定されていたりすると気付かれないケースもあると判明した。

なので、管理画面に「このUserとしてSignup済み」の項目を追加し、ApproveしたもののSignupが済んでいない人がいたときに、気付きやすくしておく。
