### PR TITLE
Googleから渡ってくるpictureの情報がなければ、Gravatarすればいいじゃない

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -31,7 +31,7 @@ class SessionsController < ApplicationController
           google_guid: payload["sub"],
           email: email,
           name: email.split("@").first,
-          icon_url: payload["picture"]
+          icon_url: payload["picture"].presence || "https://www.gravatar.com/avatar/#{Digest::MD5.hexdigest(email.downcase)}?d=identicon"
         )
         log_in(user)
         redirect_to root_path, notice: "Logged in"
@@ -40,7 +40,7 @@ class SessionsController < ApplicationController
         session[:pending_auth] = {
           "google_guid" => payload["sub"],
           "email" => email,
-          "icon_url" => payload["picture"],
+          "icon_url" => payload["picture"].presence || "https://www.gravatar.com/avatar/#{Digest::MD5.hexdigest(email.downcase)}?d=identicon",
           "name" => email.split("@").first
         }
         redirect_to new_join_request_path


### PR DESCRIPTION
Google認証のあとに受け取るpayloadにおいて、プロフィール画像がnilの場合もあるみたい。想定していなくて、ログインに失敗しちゃう事象が観測されたので、nilも考慮した実装にします。

nilの場合はどうしようと考えて、emailからGravatarの画像URLを生成して使うことにしてみます。悪くはないでしょう。
