### PR TITLE
Userのsignup時の仮name決定ロジックを見直す

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -30,7 +30,7 @@ class SessionsController < ApplicationController
         user = User.create!(
           google_guid: payload["sub"],
           email: email,
-          name: email.split("@").first,
+          name: User.generate_default_name(email),
           icon_url: payload["picture"].presence || "https://www.gravatar.com/avatar/#{Digest::MD5.hexdigest(email.downcase)}?d=identicon"
         )
         log_in(user)
@@ -41,7 +41,7 @@ class SessionsController < ApplicationController
           "google_guid" => payload["sub"],
           "email" => email,
           "icon_url" => payload["picture"].presence || "https://www.gravatar.com/avatar/#{Digest::MD5.hexdigest(email.downcase)}?d=identicon",
-          "name" => email.split("@").first
+          "name" => User.generate_default_name(email)
         }
         redirect_to new_join_request_path
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,11 @@ class User < ApplicationRecord
   validates :icon_url, presence: true
   validates_url_http_format_of :icon_url
 
+  def self.generate_default_name(email)
+    local_part = email.split("@").first
+    local_part.length >= 2 ? local_part : email.gsub("@", ".")
+  end
+
   def admin?
     admin == true
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+class UserTest < ActiveSupport::TestCase
+  describe "generate_default_name" do
+    test "generates default name from email" do
+      test_cases = [
+        # 2文字以上のローカル部分はそのまま使用
+        { email: "alice@example.com", name: "alice" },
+        { email: "bob@example.org", name: "bob" },
+        { email: "test@gmail.com", name: "test" },
+
+        # 1文字のローカル部分は@を.に置き換え
+        { email: "a@example.com", name: "a.example.com" },
+        { email: "x@example.org", name: "x.example.org" },
+        { email: "z@test.jp", name: "z.test.jp" },
+
+        # エッジケース
+        { email: "ab@example.com", name: "ab" },
+        { email: "verylongemailaddress@example.com", name: "verylongemailaddress" },
+        { email: "a@sub.domain.example.com", name: "a.sub.domain.example.com" }
+      ]
+
+      test_cases.each do |test_case|
+        assert_equal test_case[:name], User.generate_default_name(test_case[:email]),
+                     "Expected #{test_case[:email]} to generate name '#{test_case[:name]}'"
+      end
+    end
+  end
+end


### PR DESCRIPTION
これまでのロジックだとUserモデルのvalidationに引っかかってしまって保存に失敗するケースがあると判明したので :dash:
