### PR TITLE
Channelのfeed_url変更のDiscord通知が二重に送られるので直す

### DIFF
--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -210,8 +210,7 @@ class Channel < ApplicationRecord
         channel = Channel.find_by(feed_url: feed_url)
         if channel
           Rails.logger.info "[Channel] Detected redirect from #{feed_url} to #{final_feed_url}, updating existing channel ##{channel.id}"
-          channel.update!(feed_url: final_feed_url)
-          channel.update(parameters)
+          channel.update!(parameters.merge(feed_url: final_feed_url))
         else
           # 旧URLのチャンネルが存在しない場合は、新URLでチャンネルを作成
           channel = Channel.find_or_initialize_by(feed_url: final_feed_url)


### PR DESCRIPTION
<img width="474" height="206" alt="_content-updates___rururu_-_Discord" src="https://github.com/user-attachments/assets/3d7db8a5-60e4-4397-a2bf-519ef7ec408e" />
