### PR TITLE
Channelのfeed_url変更のDiscord通知が二重に送られるので直す・続

### DIFF
--- a/app/jobs/channel_items_updater_job.rb
+++ b/app/jobs/channel_items_updater_job.rb
@@ -4,6 +4,8 @@ class ChannelItemsUpdaterJob < ApplicationJob
 
     begin
       channel.update_info
+      # リダイレクトでfeed_urlが更新された場合、メモリ上のオブジェクトを最新の状態にする
+      channel.reload
     rescue StandardError => e
       handle_error(e, channel, "Failed to update channel info")
     end


### PR DESCRIPTION
- https://github.com/kairan-app/feeeed/pull/588

では不十分だったので、追撃です :person_fencing:
