### PR TITLE
Itemのimage_urlの前後の空白文字は詰める

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -14,7 +14,7 @@ class Item < ApplicationRecord
   validates :published_at, presence: true
   validates_url_http_format_of :url, :image_url
 
-  strip_before_save :title
+  strip_before_save :title, :image_url
   empty_strings_are_aligned_to_nil :image_url
   after_create_commit { ItemCreationNotifierJob.perform_later(self.id) }
 


### PR DESCRIPTION
https://www.tfm.co.jp/lock/nogizaka46/inouenagi/44327 のog:imageが

```
<meta property="og:image" content="        https://www.tfm.co.jp/lock/craft/assets/井上和LOCKS251202TOP.jpg
  ">
```

こんな感じで空白文字を含んでいて、これをItemのimage_urlに保存して表示しようとして例外が起きていた。詰めます :scissors:
