### PR TITLE
未ログイン状態でもItemカードを表示できるように

### DIFF
--- a/app/views/items/_cards.html.erb
+++ b/app/views/items/_cards.html.erb
@@ -20,7 +20,7 @@
       </span>
     <% end %>
     <span class="block mb-[0.1em] text-[0.9em] leading-[1.5em] text-[#555555]"><%= item.published_at.strftime("%Y-%m-%d %H:%M") %></span>
-    <%= render(partial: "items/pawprint", locals: { item: item, pawprint: item.pawprints.find { |p| p.user_id == current_user.id } }) %>
+    <%= render(partial: "items/pawprint", locals: { item: item, pawprint: item.pawprints.find { |p| p.user_id == current_user&.id } }) %>
   </div>
   <% end %>
 </div>

--- a/test/factories/channel_groups.rb
+++ b/test/factories/channel_groups.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :channel_group do
+    association :owner, factory: :user
+    sequence(:name) { |n| "Test Channel Group #{n}" }
+  end
+end

--- a/test/factories/items.rb
+++ b/test/factories/items.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :item do
+    channel
+    sequence(:guid) { |n| "guid-#{n}" }
+    sequence(:title) { |n| "Test Item #{n}" }
+    sequence(:url) { |n| "https://example.com/item#{n}" }
+    published_at { Time.current }
+  end
+end

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :user do
+    sequence(:name) { |n| "testuser#{n}" }
+    sequence(:email) { |n| "testuser#{n}@example.com" }
+    sequence(:google_guid) { |n| "google-guid-#{n}" }
+    icon_url { "https://example.com/icon.png" }
+  end
+end

--- a/test/integration/guest_access_test.rb
+++ b/test/integration/guest_access_test.rb
@@ -1,0 +1,81 @@
+require "test_helper"
+
+class GuestAccessTest < ActionDispatch::IntegrationTest
+  setup do
+    @channel = create(:channel)
+    @item = create(:item, channel: @channel)
+    @user = create(:user)
+    @channel_group = create(:channel_group, owner: @user)
+  end
+
+  test "guest can access root page" do
+    get "/"
+    assert_response :success
+  end
+
+  test "guest can access channels index" do
+    get "/channels"
+    assert_response :success
+  end
+
+  test "guest can access channel show" do
+    get "/channels/#{@channel.id}"
+    assert_response :success
+  end
+
+  test "guest can access items index" do
+    get "/items"
+    assert_response :success
+  end
+
+  test "guest can access channel_groups index" do
+    get "/channel_groups"
+    assert_response :success
+  end
+
+  test "guest can access channel_group show" do
+    get "/channel_groups/#{@channel_group.id}"
+    assert_response :success
+  end
+
+  test "guest can access users index" do
+    get "/users"
+    assert_response :success
+  end
+
+  test "guest can access user show" do
+    get "/@#{@user.name}"
+    assert_response :success
+  end
+
+  test "guest can access user pawprints as json" do
+    get "/@#{@user.name}/pawprints", as: :json
+    assert_response :success
+  end
+
+  test "guest can access user subscribed_items as json" do
+    get "/@#{@user.name}/subscribed_items", as: :json
+    assert_response :success
+  end
+
+  test "guest can access about page" do
+    get "/about"
+    assert_response :success
+  end
+
+  test "guest can access terms page" do
+    get "/terms"
+    assert_response :success
+  end
+
+  test "guest can access privacy page" do
+    get "/privacy"
+    assert_response :success
+  end
+
+  # join_requests/new requires pending_auth session (redirects without it)
+  test "guest is redirected from join_requests/new without pending auth" do
+    get "/join_requests/new"
+    assert_response :redirect
+  end
+end


### PR DESCRIPTION
ログインチェックが甘くて、Pawprintの情報を引こうとしてnil例外を起こしていました :sob:
主要なページ群にゲストアクセスするテストケースを足しておいたので、今後は気付きやすくなるはず :muscle:
