### PR TITLE
Load more unreadsの件数チェックの不備を直す

### DIFF
--- a/app/controllers/my/unreads/channels/items_controller.rb
+++ b/app/controllers/my/unreads/channels/items_controller.rb
@@ -6,15 +6,16 @@ class My::Unreads::Channels::ItemsController < MyController
     @range_days = params[:range_days].to_i
     @item_summary_line_clamp = session[:item_summary_line_clamp] || 4
 
-    @items = current_user.unread_items_for(
+    items_with_check = current_user.unread_items_for(
       @channel,
       offset: @offset,
-      limit: @limit,
+      limit: @limit + 1,
       range_days: @range_days
     )
 
+    @items = items_with_check.take(@limit)
     @next_offset = @offset + @limit
-    @has_more = @items.size >= @limit
+    @has_more = items_with_check.size > @limit
 
     respond_to do |format|
       format.turbo_stream

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,9 @@ Rails.application.routes.draw do
 
   if Rails.env.development?
     mount LetterOpenerWeb::Engine => "/letter_opener"
+  end
+
+  if Rails.env.local?
     get "/dev/login", to: "dev#login"
   end
 

--- a/test/integration/my/unreads/channels/items_test.rb
+++ b/test/integration/my/unreads/channels/items_test.rb
@@ -1,0 +1,75 @@
+require "test_helper"
+
+class My::Unreads::Channels::ItemsTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = create(:user)
+    @channel = create(:channel)
+    @user.subscribe(@channel)
+  end
+
+  test "has_more is false when exactly limit items remain" do
+    # 6件のunread itemsを作成（最初に3件表示、残り3件）
+    6.times do |i|
+      create(:item, channel: @channel, published_at: i.hours.ago)
+    end
+
+    sign_in(@user)
+
+    # offset=3, limit=3 でリクエスト（残り3件をすべて取得）
+    get my_unreads_channel_items_path(
+      channel_id: @channel.id,
+      offset: 3,
+      limit: 3,
+      range_days: 7
+    ), as: :turbo_stream
+
+    assert_response :success
+
+    # ボタンが消えることを確認（has_moreがfalseなので空のreplaceになる）
+    assert_no_match(/Load more unreads/, response.body)
+  end
+
+  test "has_more is true when more items remain beyond limit" do
+    # 7件のunread itemsを作成（最初に3件表示、残り4件）
+    7.times do |i|
+      create(:item, channel: @channel, published_at: i.hours.ago)
+    end
+
+    sign_in(@user)
+
+    # offset=3, limit=3 でリクエスト（残り4件のうち3件取得）
+    get my_unreads_channel_items_path(
+      channel_id: @channel.id,
+      offset: 3,
+      limit: 3,
+      range_days: 7
+    ), as: :turbo_stream
+
+    assert_response :success
+
+    # ボタンが表示されることを確認（まだ1件残っている）
+    assert_match(/Load more unreads/, response.body)
+  end
+
+  test "has_more is false when no items remain" do
+    # 3件のunread itemsを作成（最初に3件表示、残り0件）
+    3.times do |i|
+      create(:item, channel: @channel, published_at: i.hours.ago)
+    end
+
+    sign_in(@user)
+
+    # offset=3, limit=3 でリクエスト（残り0件）
+    get my_unreads_channel_items_path(
+      channel_id: @channel.id,
+      offset: 3,
+      limit: 3,
+      range_days: 7
+    ), as: :turbo_stream
+
+    assert_response :success
+
+    # ボタンが消えることを確認
+    assert_no_match(/Load more unreads/, response.body)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,3 +16,9 @@ module ActiveSupport
     include FactoryBot::Syntax::Methods
   end
 end
+
+class ActionDispatch::IntegrationTest
+  def sign_in(user)
+    get "/dev/login", params: { user_id: user.id }
+  end
+end


### PR DESCRIPTION
Unreadsページにて、未読のItemがあと3件あるときに「Load more unreads」ボタンを押すと、その3件が継ぎ足しされた上で「Load more unreads」ボタンは残る、という挙動になっていました。

ほんで、もっかいボタンを押すと0件が継ぎ足しされてボタンが消える、と。追加のItemが残っていなければボタンは消えてほしいのに、判定がそのようになっていませんでした。直します！
