### PR TITLE
HTMLのtitleに、Production以外では目印をつけておく

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,13 @@
 module ApplicationHelper
+  ENVIRONMENT_TITLE_PREFIXES = {
+    "development" => "👷"
+  }.freeze
+
+  def with_environment_prefix(text)
+    prefix = ENVIRONMENT_TITLE_PREFIXES[Rails.env]
+    [ prefix, text ].compact.join(" ").presence
+  end
+
   def id_of_pawprint_form_for(item)
     "pawprint-form-for-item-#{item.id}"
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= [@title, "rururu"].compact.join(" - ") %></title>
+    <title><%= [with_environment_prefix(@title), "rururu"].compact.join(" - ") %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>


### PR DESCRIPTION
ウェブブラウザでタブを開いているときに、ProductionとDevelopmentの見分けがつきやすいとうれしいので :bulb:

<img width="294" height="164" alt="Admin_-_rururu" src="https://github.com/user-attachments/assets/08ecec68-15b9-41ef-8e70-0e5fc395849b" />
