### PR TITLE
オーディオ・プレイヤーを試作する

### DIFF
--- a/app/assets/images/player-pause.svg
+++ b/app/assets/images/player-pause.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="white">
+  <path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z"/>
+</svg>

--- a/app/assets/images/player-play.svg
+++ b/app/assets/images/player-play.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="white">
+  <path d="M8 5v14l11-7z"/>
+</svg>

--- a/app/assets/images/player-skip-back.svg
+++ b/app/assets/images/player-skip-back.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#6b7280">
+  <path d="M12 5V1L7 6l5 5V7c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z"/>
+  <text x="12" y="15.5" text-anchor="middle" font-size="7" font-weight="bold" font-family="system-ui, sans-serif" fill="#6b7280">15</text>
+</svg>

--- a/app/assets/images/player-skip-forward.svg
+++ b/app/assets/images/player-skip-forward.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#6b7280">
+  <path d="M12 5V1l5 5-5 5V7c-3.31 0-6 2.69-6 6s2.69 6 6 6 6-2.69 6-6h2c0 4.42-3.58 8-8 8s-8-3.58-8-8 3.58-8 8-8z"/>
+  <text x="12" y="15.5" text-anchor="middle" font-size="7" font-weight="bold" font-family="system-ui, sans-serif" fill="#6b7280">30</text>
+</svg>

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -67,3 +67,15 @@ textarea {
   transform: scale(1.1);
   z-index: 1;
 }
+
+/* 音声プレイヤー表示時にフローティングボタンを上にずらす */
+body.audio-player-visible label[for="channel-registration-form"]:last-of-type {
+  bottom: calc(20px + 72px); /* 通常の bottom-5 + プレイヤーの高さ */
+  transition: bottom 0.2s ease-out;
+}
+
+@media screen and (max-width: 768px) {
+  body.audio-player-visible label[for="channel-registration-form"]:last-of-type {
+    bottom: calc(80px + 64px + 130px); /* モバイルの bottom-20 + ナビ高さ + プレイヤーの高さ */
+  }
+}

--- a/app/javascript/controllers/audio_item_controller.js
+++ b/app/javascript/controllers/audio_item_controller.js
@@ -1,0 +1,49 @@
+import { Controller } from "@hotwired/stimulus"
+
+// 各Itemの「キューに追加」「再生」ボタンを制御するコントローラー
+export default class extends Controller {
+  static values = {
+    itemId: Number,
+    title: String,
+    url: String,
+    channelTitle: String,
+    imageUrl: String
+  }
+
+  addToQueue() {
+    this.dispatchAudioEvent("audio:addToQueue", this.buildItem())
+    this.showAddedFeedback()
+  }
+
+  playNow() {
+    this.dispatchAudioEvent("audio:playNow", this.buildItem())
+  }
+
+  buildItem() {
+    return {
+      itemId: this.itemIdValue,
+      title: this.titleValue,
+      url: this.urlValue,
+      channelTitle: this.channelTitleValue,
+      imageUrl: this.imageUrlValue
+    }
+  }
+
+  dispatchAudioEvent(eventName, detail) {
+    document.dispatchEvent(new CustomEvent(eventName, { detail }))
+  }
+
+  showAddedFeedback() {
+    // 一時的にボタンテキストを変更してフィードバック
+    const button = this.element.querySelector("[data-audio-item-add-button]")
+    if (button) {
+      const originalText = button.innerHTML
+      button.innerHTML = '<span class="material-symbols-outlined text-sm">check</span> 追加済み'
+      button.disabled = true
+      setTimeout(() => {
+        button.innerHTML = originalText
+        button.disabled = false
+      }, 1500)
+    }
+  }
+}

--- a/app/javascript/controllers/audio_player_controller.js
+++ b/app/javascript/controllers/audio_player_controller.js
@@ -1,0 +1,475 @@
+import { Controller } from "@hotwired/stimulus"
+
+// グローバル音声プレイヤーのメインコントローラー
+// ページ遷移しても状態を維持する
+export default class extends Controller {
+  static targets = [
+    "audio",
+    "playButton",
+    "playIcon",
+    "progress",
+    "progressBar",
+    "currentTime",
+    "duration",
+    "speed",
+    "title",
+    "channel",
+    "queueCount",
+    "queuePanel",
+    "queueList",
+    "container",
+    // モバイル用ターゲット
+    "playButtonMobile",
+    "playIconMobile",
+    "progressMobile",
+    "progressBarMobile",
+    "currentTimeMobile",
+    "durationMobile",
+    "speedMobile",
+    "titleMobile",
+    "channelMobile",
+    "queueCountMobile"
+  ]
+
+  static values = {
+    queue: { type: Array, default: [] },
+    currentIndex: { type: Number, default: 0 },
+    playbackRate: { type: Number, default: 1.0 },
+    isPlaying: { type: Boolean, default: false }
+  }
+
+  connect() {
+    this.loadFromStorage()
+    this.setupEventListeners()
+    this.updateUI()
+  }
+
+  disconnect() {
+    this.saveToStorage()
+  }
+
+  // === Storage ===
+  loadFromStorage() {
+    try {
+      const data = localStorage.getItem("feeeed:audioPlayer")
+      if (data) {
+        const parsed = JSON.parse(data)
+        this.queueValue = parsed.queue || []
+        this.currentIndexValue = parsed.currentIndex || 0
+        this.playbackRateValue = parsed.playbackRate || 1.0
+
+        if (this.queueValue.length > 0 && parsed.currentTime) {
+          this.pendingSeek = parsed.currentTime
+        }
+      }
+    } catch (e) {
+      console.error("Failed to load audio player state:", e)
+    }
+  }
+
+  saveToStorage() {
+    try {
+      const data = {
+        queue: this.queueValue,
+        currentIndex: this.currentIndexValue,
+        playbackRate: this.playbackRateValue,
+        currentTime: this.hasAudioTarget ? this.audioTarget.currentTime : 0
+      }
+      localStorage.setItem("feeeed:audioPlayer", JSON.stringify(data))
+    } catch (e) {
+      console.error("Failed to save audio player state:", e)
+    }
+  }
+
+  // === Event Listeners ===
+  setupEventListeners() {
+    // キュー追加イベントを受信
+    document.addEventListener("audio:addToQueue", this.handleAddToQueue.bind(this))
+    document.addEventListener("audio:addAllToQueue", this.handleAddAllToQueue.bind(this))
+    document.addEventListener("audio:playNow", this.handlePlayNow.bind(this))
+
+    // ページ離脱時に保存
+    window.addEventListener("beforeunload", () => this.saveToStorage())
+
+    // Turbo ナビゲーション時にも保存
+    document.addEventListener("turbo:before-visit", () => this.saveToStorage())
+  }
+
+  handleAddToQueue(event) {
+    this.addToQueue(event.detail)
+  }
+
+  handleAddAllToQueue(event) {
+    const items = event.detail.items || []
+    items.forEach(item => this.addToQueue(item, false))
+    this.updateUI()
+    this.saveToStorage()
+  }
+
+  handlePlayNow(event) {
+    this.addToQueue(event.detail)
+    this.currentIndexValue = this.queueValue.length - 1
+    this.loadCurrentTrack()
+    this.play()
+  }
+
+  // === Queue Management ===
+  addToQueue(item, updateUI = true) {
+    // 重複チェック
+    const exists = this.queueValue.some(q => q.itemId === item.itemId)
+    if (exists) return
+
+    this.queueValue = [...this.queueValue, item]
+
+    if (updateUI) {
+      this.updateUI()
+      this.saveToStorage()
+    }
+
+    // 最初のアイテムなら読み込む
+    if (this.queueValue.length === 1) {
+      this.loadCurrentTrack()
+    }
+  }
+
+  removeFromQueue(event) {
+    const index = parseInt(event.currentTarget.dataset.index, 10)
+    const wasPlaying = this.isPlayingValue
+    const wasCurrentTrack = index === this.currentIndexValue
+
+    this.queueValue = this.queueValue.filter((_, i) => i !== index)
+
+    if (index < this.currentIndexValue) {
+      this.currentIndexValue--
+    } else if (wasCurrentTrack) {
+      if (this.currentIndexValue >= this.queueValue.length) {
+        this.currentIndexValue = Math.max(0, this.queueValue.length - 1)
+      }
+      this.loadCurrentTrack()
+      if (wasPlaying && this.queueValue.length > 0) {
+        this.play()
+      }
+    }
+
+    this.updateUI()
+    this.saveToStorage()
+  }
+
+  clearQueue() {
+    this.pause()
+    this.queueValue = []
+    this.currentIndexValue = 0
+    this.updateUI()
+    this.saveToStorage()
+  }
+
+  // === Playback Control ===
+  loadCurrentTrack() {
+    if (!this.hasAudioTarget || this.queueValue.length === 0) return
+
+    const current = this.queueValue[this.currentIndexValue]
+    if (!current) return
+
+    this.audioTarget.src = current.url
+    this.audioTarget.playbackRate = this.playbackRateValue
+
+    if (this.pendingSeek) {
+      this.audioTarget.currentTime = this.pendingSeek
+      this.pendingSeek = null
+    }
+
+    this.updateUI()
+  }
+
+  toggle() {
+    if (this.isPlayingValue) {
+      this.pause()
+    } else {
+      this.play()
+    }
+  }
+
+  play() {
+    if (!this.hasAudioTarget || this.queueValue.length === 0) return
+
+    if (!this.audioTarget.src) {
+      this.loadCurrentTrack()
+    }
+
+    this.audioTarget.play().then(() => {
+      this.isPlayingValue = true
+      this.updatePlayButton()
+    }).catch(e => {
+      console.error("Play failed:", e)
+    })
+  }
+
+  pause() {
+    if (!this.hasAudioTarget) return
+    this.audioTarget.pause()
+    this.isPlayingValue = false
+    this.updatePlayButton()
+  }
+
+  skipBackward() {
+    if (!this.hasAudioTarget) return
+    this.audioTarget.currentTime = Math.max(0, this.audioTarget.currentTime - 15)
+  }
+
+  skipForward() {
+    if (!this.hasAudioTarget) return
+    this.audioTarget.currentTime += 30
+  }
+
+  previous() {
+    if (this.currentIndexValue > 0) {
+      this.currentIndexValue--
+      this.loadCurrentTrack()
+      this.play()
+    }
+  }
+
+  next() {
+    if (this.currentIndexValue < this.queueValue.length - 1) {
+      this.currentIndexValue++
+      this.loadCurrentTrack()
+      this.play()
+    } else {
+      // キュー終了
+      this.pause()
+    }
+  }
+
+  playAt(event) {
+    const index = parseInt(event.currentTarget.dataset.index, 10)
+    this.currentIndexValue = index
+    this.loadCurrentTrack()
+    this.play()
+  }
+
+  // === Speed Control ===
+  cycleSpeed() {
+    const speeds = [0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0]
+    const currentIdx = speeds.indexOf(this.playbackRateValue)
+    const nextIdx = (currentIdx + 1) % speeds.length
+    this.playbackRateValue = speeds[nextIdx]
+
+    if (this.hasAudioTarget) {
+      this.audioTarget.playbackRate = this.playbackRateValue
+    }
+
+    this.updateSpeedDisplay()
+    this.saveToStorage()
+  }
+
+  // === Progress ===
+  seek(event) {
+    if (!this.hasAudioTarget || !this.hasProgressTarget) return
+
+    const rect = this.progressTarget.getBoundingClientRect()
+    const percent = (event.clientX - rect.left) / rect.width
+    const time = percent * this.audioTarget.duration
+
+    if (!isNaN(time)) {
+      this.audioTarget.currentTime = time
+    }
+  }
+
+  seekMobile(event) {
+    if (!this.hasAudioTarget || !this.hasProgressMobileTarget) return
+
+    const rect = this.progressMobileTarget.getBoundingClientRect()
+    const percent = (event.clientX - rect.left) / rect.width
+    const time = percent * this.audioTarget.duration
+
+    if (!isNaN(time)) {
+      this.audioTarget.currentTime = time
+    }
+  }
+
+  onTimeUpdate() {
+    this.updateProgress()
+    // 5秒ごとに保存
+    if (Math.floor(this.audioTarget.currentTime) % 5 === 0) {
+      this.saveToStorage()
+    }
+  }
+
+  onEnded() {
+    this.next()
+  }
+
+  onLoadedMetadata() {
+    this.updateProgress()
+  }
+
+  // === Queue Panel ===
+  toggleQueuePanel() {
+    if (this.hasQueuePanelTarget) {
+      this.queuePanelTarget.classList.toggle("hidden")
+    }
+  }
+
+  closePlayer() {
+    this.clearQueue()
+  }
+
+  // === UI Updates ===
+  updateUI() {
+    this.updateVisibility()
+    this.updateTrackInfo()
+    this.updateQueueCount()
+    this.updateQueueList()
+    this.updatePlayButton()
+    this.updateSpeedDisplay()
+    this.updateProgress()
+  }
+
+  updateVisibility() {
+    if (this.hasContainerTarget) {
+      if (this.queueValue.length === 0) {
+        this.containerTarget.classList.add("hidden")
+        document.body.classList.remove("audio-player-visible")
+      } else {
+        this.containerTarget.classList.remove("hidden")
+        document.body.classList.add("audio-player-visible")
+      }
+    }
+  }
+
+  updateTrackInfo() {
+    const current = this.queueValue[this.currentIndexValue]
+    const title = current?.title || ""
+    const channelTitle = current?.channelTitle || ""
+
+    if (this.hasTitleTarget) {
+      this.titleTarget.textContent = title
+    }
+    if (this.hasTitleMobileTarget) {
+      this.titleMobileTarget.textContent = title
+    }
+    if (this.hasChannelTarget) {
+      this.channelTarget.textContent = channelTitle
+    }
+    if (this.hasChannelMobileTarget) {
+      this.channelMobileTarget.textContent = channelTitle
+    }
+  }
+
+  updateQueueCount() {
+    const count = this.queueValue.length
+    if (this.hasQueueCountTarget) {
+      this.queueCountTarget.textContent = count
+    }
+    if (this.hasQueueCountMobileTarget) {
+      this.queueCountMobileTarget.textContent = count
+    }
+  }
+
+  updateQueueList() {
+    if (!this.hasQueueListTarget) return
+
+    this.queueListTarget.innerHTML = this.queueValue.map((item, index) => `
+      <div class="flex items-center gap-2 p-2 ${index === this.currentIndexValue ? 'bg-blue-100' : 'hover:bg-gray-100'} rounded cursor-pointer group"
+           data-action="click->audio-player#playAt"
+           data-index="${index}">
+        <span class="w-6 text-center text-sm text-gray-500">
+          ${index === this.currentIndexValue && this.isPlayingValue ? '▶' : (index + 1)}
+        </span>
+        <div class="flex-1 min-w-0">
+          <div class="text-sm font-medium truncate">${this.escapeHtml(item.title)}</div>
+          <div class="text-xs text-gray-500 truncate">${this.escapeHtml(item.channelTitle)}</div>
+        </div>
+        <button class="opacity-0 group-hover:opacity-100 p-1 text-gray-400 hover:text-red-500"
+                data-action="click->audio-player#removeFromQueue:stop"
+                data-index="${index}">
+          <span class="material-symbols-outlined text-lg">close</span>
+        </button>
+      </div>
+    `).join("")
+  }
+
+  updatePlayButton() {
+    // デスクトップ用
+    this._updatePlayButtonPair(this.playButtonTarget, this.playIconTarget)
+    // モバイル用
+    this._updatePlayButtonPair(this.playButtonMobileTarget, this.playIconMobileTarget)
+  }
+
+  _updatePlayButtonPair(buttonTarget, iconTarget) {
+    if (!iconTarget || !buttonTarget) return
+
+    // img タグの場合は data 属性から src を取得、span の場合は textContent を切り替え
+    if (iconTarget.tagName === "IMG") {
+      const playIcon = buttonTarget.dataset.playIcon
+      const pauseIcon = buttonTarget.dataset.pauseIcon
+      iconTarget.src = this.isPlayingValue ? pauseIcon : playIcon
+      iconTarget.alt = this.isPlayingValue ? "一時停止" : "再生"
+      // 一時停止アイコンは中央揃えなので ml-0.5 を外す
+      iconTarget.classList.toggle("ml-0.5", !this.isPlayingValue)
+    } else {
+      iconTarget.textContent = this.isPlayingValue ? "pause" : "play_arrow"
+    }
+  }
+
+  updateSpeedDisplay() {
+    const speedText = `${this.playbackRateValue}x`
+    // モバイルは短い表示（1.0x → 1x, 1.5x はそのまま）
+    const speedTextMobile = this.playbackRateValue === Math.floor(this.playbackRateValue)
+      ? `${Math.floor(this.playbackRateValue)}x`
+      : `${this.playbackRateValue}x`
+
+    if (this.hasSpeedTarget) {
+      this.speedTarget.textContent = speedText
+    }
+    if (this.hasSpeedMobileTarget) {
+      this.speedMobileTarget.textContent = speedTextMobile
+    }
+  }
+
+  updateProgress() {
+    if (!this.hasAudioTarget) return
+
+    const current = this.audioTarget.currentTime || 0
+    const duration = this.audioTarget.duration || 0
+    const percent = duration > 0 ? (current / duration) * 100 : 0
+    const currentTimeText = this.formatTime(current)
+    const durationText = this.formatTime(duration)
+
+    // デスクトップ用
+    if (this.hasProgressBarTarget) {
+      this.progressBarTarget.style.width = `${percent}%`
+    }
+    if (this.hasCurrentTimeTarget) {
+      this.currentTimeTarget.textContent = currentTimeText
+    }
+    if (this.hasDurationTarget) {
+      this.durationTarget.textContent = durationText
+    }
+
+    // モバイル用
+    if (this.hasProgressBarMobileTarget) {
+      this.progressBarMobileTarget.style.width = `${percent}%`
+    }
+    if (this.hasCurrentTimeMobileTarget) {
+      this.currentTimeMobileTarget.textContent = currentTimeText
+    }
+    if (this.hasDurationMobileTarget) {
+      this.durationMobileTarget.textContent = durationText
+    }
+  }
+
+  // === Utilities ===
+  formatTime(seconds) {
+    if (!seconds || isNaN(seconds)) return "0:00"
+    const mins = Math.floor(seconds / 60)
+    const secs = Math.floor(seconds % 60)
+    return `${mins}:${secs.toString().padStart(2, "0")}`
+  }
+
+  escapeHtml(text) {
+    const div = document.createElement("div")
+    div.textContent = text
+    return div.innerHTML
+  }
+}

--- a/app/javascript/controllers/audio_queue_all_controller.js
+++ b/app/javascript/controllers/audio_queue_all_controller.js
@@ -1,0 +1,37 @@
+import { Controller } from "@hotwired/stimulus"
+
+// ページ内の全オーディオアイテムを一括でキューに追加するコントローラー
+export default class extends Controller {
+  addAll() {
+    // ページ内の audio-item コントローラーを持つ要素を全て取得
+    const audioItems = document.querySelectorAll("[data-controller~='audio-item']")
+
+    const items = Array.from(audioItems).map(el => {
+      return {
+        itemId: parseInt(el.dataset.audioItemItemIdValue, 10),
+        title: el.dataset.audioItemTitleValue,
+        url: el.dataset.audioItemUrlValue,
+        channelTitle: el.dataset.audioItemChannelTitleValue,
+        imageUrl: el.dataset.audioItemImageUrlValue
+      }
+    }).filter(item => item.url) // URLがあるもののみ
+
+    if (items.length > 0) {
+      document.dispatchEvent(new CustomEvent("audio:addAllToQueue", {
+        detail: { items }
+      }))
+      this.showFeedback(items.length)
+    }
+  }
+
+  showFeedback(count) {
+    const button = this.element.querySelector("button") || this.element
+    const originalText = button.innerHTML
+    button.innerHTML = `<span class="material-symbols-outlined text-sm">check</span> ${count}件追加`
+    button.disabled = true
+    setTimeout(() => {
+      button.innerHTML = originalText
+      button.disabled = false
+    }, 2000)
+  }
+}

--- a/app/views/items/_audio_queue_button.html.erb
+++ b/app/views/items/_audio_queue_button.html.erb
@@ -1,0 +1,25 @@
+<%# 音声アイテムのキュー追加ボタン %>
+<%# locals: item, size: :normal %>
+<% size ||= :normal %>
+<% button_class = size == :small ? "text-xs py-1 px-2" : "text-sm py-1.5 px-3" %>
+<% icon_size = size == :small ? "text-sm" : "text-base" %>
+
+<div data-controller="audio-item"
+     data-audio-item-item-id-value="<%= item.id %>"
+     data-audio-item-title-value="<%= item.title %>"
+     data-audio-item-url-value="<%= item.audio_enclosure_url %>"
+     data-audio-item-channel-title-value="<%= item.channel.title %>"
+     data-audio-item-image-url-value="<%= item.image_url_or_placeholder %>"
+     class="audio-queue-buttons flex gap-1 flex-wrap">
+  <button data-action="audio-item#playNow"
+          class="inline-flex items-center gap-1 <%= button_class %> bg-[#3d8bcd] text-white rounded hover:bg-[#2d7bbd] transition-colors">
+    <span class="material-symbols-outlined <%= icon_size %>">play_arrow</span>
+    <span>再生</span>
+  </button>
+  <button data-action="audio-item#addToQueue"
+          data-audio-item-add-button
+          class="inline-flex items-center gap-1 <%= button_class %> bg-gray-100 text-gray-700 rounded hover:bg-gray-200 transition-colors">
+    <span class="material-symbols-outlined <%= icon_size %>">add</span>
+    <span>キューに追加</span>
+  </button>
+</div>

--- a/app/views/items/_cards.html.erb
+++ b/app/views/items/_cards.html.erb
@@ -8,8 +8,8 @@
         </div>
       <% end %>
       <% if item.audio_enclosure_url %>
-        <div class="audio-player audio-player-on-the-image absolute bottom-0 w-[96%] my-1 mx-[2%] z-10">
-          <audio class="h-[30px]" style="width: 100%;" src="<%= item.audio_enclosure_url %>" controls controlslist="nodownload"></audio>
+        <div class="absolute bottom-0 w-[96%] my-1 mx-[2%] z-10">
+          <%= render(partial: "items/audio_queue_button", locals: { item: item, size: :small }) %>
         </div>
       <% end %>
     </div>

--- a/app/views/layouts/_global_audio_player.html.erb
+++ b/app/views/layouts/_global_audio_player.html.erb
@@ -1,0 +1,174 @@
+<%# グローバル音声プレイヤー - ページ遷移しても維持される %>
+<div id="global-audio-player"
+     data-turbo-permanent
+     data-controller="audio-player"
+     data-audio-player-target="container"
+     class="hidden fixed bottom-16 md:bottom-0 left-0 right-0 z-50 bg-white border-t border-gray-200 shadow-lg">
+
+  <%# 非表示のaudio要素 %>
+  <audio data-audio-player-target="audio"
+         data-action="timeupdate->audio-player#onTimeUpdate ended->audio-player#onEnded loadedmetadata->audio-player#onLoadedMetadata"
+         preload="metadata"></audio>
+
+  <%# キューパネル（展開時） %>
+  <div data-audio-player-target="queuePanel"
+       class="hidden max-h-64 overflow-y-auto border-b border-gray-100 bg-gray-50">
+    <div class="max-w-[1440px] mx-auto px-4 py-2">
+      <div class="flex justify-between items-center mb-2">
+        <span class="text-sm font-medium text-gray-700">再生キュー</span>
+        <div class="flex gap-2">
+          <button data-action="audio-player#clearQueue"
+                  class="text-xs text-gray-500 hover:text-red-500">
+            クリア
+          </button>
+          <button data-action="audio-player#toggleQueuePanel"
+                  class="text-gray-400 hover:text-gray-600">
+            <span class="material-symbols-outlined text-lg">expand_more</span>
+          </button>
+        </div>
+      </div>
+      <div data-audio-player-target="queueList" class="space-y-1"></div>
+    </div>
+  </div>
+
+  <%# メインプレイヤー %>
+  <div class="max-w-[1440px] mx-auto px-3 py-2 md:px-4">
+
+    <%# === モバイル用レイアウト (3段) === %>
+    <div class="md:hidden">
+      <%# 上段: トラック情報 + 閉じるボタン %>
+      <div class="flex items-center gap-2 mb-1">
+        <div class="flex-1 min-w-0">
+          <div data-audio-player-target="titleMobile" class="text-sm font-medium truncate"></div>
+          <div class="flex items-center gap-2 text-xs text-gray-500">
+            <span data-audio-player-target="channelMobile" class="truncate"></span>
+            <span class="flex-shrink-0">
+              <span data-audio-player-target="currentTimeMobile">0:00</span>
+              /
+              <span data-audio-player-target="durationMobile">0:00</span>
+            </span>
+          </div>
+        </div>
+        <button data-action="audio-player#closePlayer"
+                class="w-7 h-7 flex items-center justify-center text-gray-400 hover:text-gray-600"
+                title="閉じる">
+          <span class="material-symbols-outlined text-lg">close</span>
+        </button>
+      </div>
+
+      <%# 中段: プログレスバー %>
+      <div data-audio-player-target="progressMobile"
+           data-action="click->audio-player#seekMobile"
+           class="h-1.5 bg-gray-200 rounded-full cursor-pointer mb-2">
+        <div data-audio-player-target="progressBarMobile"
+             class="h-full bg-[#3d8bcd] rounded-full"
+             style="width: 0%"></div>
+      </div>
+
+      <%# 下段: 速度 | ←15s | 再生 | 30s→ | キュー %>
+      <div class="flex items-center justify-center gap-2">
+        <button data-action="audio-player#cycleSpeed"
+                data-audio-player-target="speedMobile"
+                class="w-10 h-10 flex items-center justify-center text-xs font-bold text-gray-600 bg-gray-100 rounded-full active:bg-gray-200"
+                title="再生速度">
+          1x
+        </button>
+        <button data-action="audio-player#skipBackward"
+                class="w-10 h-10 flex items-center justify-center text-gray-500 active:text-gray-700 active:bg-gray-100 rounded-full"
+                title="15秒戻る">
+          <%= image_tag "player-skip-back.svg", class: "w-6 h-6", alt: "15秒戻る" %>
+        </button>
+        <button data-audio-player-target="playButtonMobile"
+                data-action="audio-player#toggle"
+                data-play-icon="<%= image_path('player-play.svg') %>"
+                data-pause-icon="<%= image_path('player-pause.svg') %>"
+                class="w-14 h-14 flex items-center justify-center bg-[#3d8bcd] text-white rounded-full shadow-md active:bg-[#2d7bbd]">
+          <%= image_tag "player-play.svg", data: { audio_player_target: "playIconMobile" }, class: "w-7 h-7 ml-0.5", alt: "再生" %>
+        </button>
+        <button data-action="audio-player#skipForward"
+                class="w-10 h-10 flex items-center justify-center text-gray-500 active:text-gray-700 active:bg-gray-100 rounded-full"
+                title="30秒進む">
+          <%= image_tag "player-skip-forward.svg", class: "w-6 h-6", alt: "30秒進む" %>
+        </button>
+        <button data-action="audio-player#toggleQueuePanel"
+                class="w-10 h-10 flex items-center justify-center text-gray-600 bg-gray-100 rounded-full active:bg-gray-200 relative"
+                title="キューを表示">
+          <span class="material-symbols-outlined text-xl">queue_music</span>
+          <span data-audio-player-target="queueCountMobile"
+                class="absolute -top-1 -right-1 min-w-[18px] h-[18px] flex items-center justify-center text-[10px] font-bold text-white bg-[#3d8bcd] rounded-full">0</span>
+        </button>
+      </div>
+    </div>
+
+    <%# === デスクトップ用レイアウト (1段) === %>
+    <div class="hidden md:block">
+      <%# プログレスバー %>
+      <div data-audio-player-target="progress"
+           data-action="click->audio-player#seek"
+           class="h-1.5 bg-gray-200 rounded-full cursor-pointer mb-2 group">
+        <div data-audio-player-target="progressBar"
+             class="h-full bg-[#3d8bcd] rounded-full transition-all group-hover:bg-[#2d7bbd]"
+             style="width: 0%"></div>
+      </div>
+
+      <%# コントロール %>
+      <div class="flex items-center gap-3">
+        <%# 再生コントロール %>
+        <div class="flex items-center gap-1">
+          <button data-action="audio-player#skipBackward"
+                  class="w-10 h-10 flex items-center justify-center text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-full transition-colors"
+                  title="15秒戻る">
+            <%= image_tag "player-skip-back.svg", class: "w-6 h-6", alt: "15秒戻る" %>
+          </button>
+          <button data-audio-player-target="playButton"
+                  data-action="audio-player#toggle"
+                  data-play-icon="<%= image_path('player-play.svg') %>"
+                  data-pause-icon="<%= image_path('player-pause.svg') %>"
+                  class="w-11 h-11 flex items-center justify-center bg-[#3d8bcd] text-white rounded-full hover:bg-[#2d7bbd] shadow-md transition-all hover:scale-105">
+            <%= image_tag "player-play.svg", data: { audio_player_target: "playIcon" }, class: "w-6 h-6 ml-0.5", alt: "再生" %>
+          </button>
+          <button data-action="audio-player#skipForward"
+                  class="w-10 h-10 flex items-center justify-center text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-full transition-colors"
+                  title="30秒進む">
+            <%= image_tag "player-skip-forward.svg", class: "w-6 h-6", alt: "30秒進む" %>
+          </button>
+        </div>
+
+        <%# トラック情報 %>
+        <div class="flex-1 min-w-0">
+          <div data-audio-player-target="title" class="text-sm font-medium truncate"></div>
+          <div class="flex items-center gap-2 text-xs text-gray-500">
+            <span data-audio-player-target="channel" class="truncate"></span>
+            <span class="flex-shrink-0">
+              <span data-audio-player-target="currentTime">0:00</span>
+              /
+              <span data-audio-player-target="duration">0:00</span>
+            </span>
+          </div>
+        </div>
+
+        <%# 速度・キュー・閉じる %>
+        <div class="flex items-center gap-1">
+          <button data-action="audio-player#cycleSpeed"
+                  data-audio-player-target="speed"
+                  class="min-w-[3rem] px-2 py-1.5 text-xs font-bold text-gray-600 bg-gray-100 rounded-full hover:bg-gray-200 transition-colors"
+                  title="再生速度">
+            1.0x
+          </button>
+          <button data-action="audio-player#toggleQueuePanel"
+                  class="flex items-center gap-1 px-2 py-1.5 text-xs text-gray-600 bg-gray-100 rounded-full hover:bg-gray-200 transition-colors"
+                  title="キューを表示">
+            <span class="material-symbols-outlined text-sm">queue_music</span>
+            <span data-audio-player-target="queueCount">0</span>
+          </button>
+          <button data-action="audio-player#closePlayer"
+                  class="w-8 h-8 flex items-center justify-center text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-full transition-colors"
+                  title="閉じる">
+            <span class="material-symbols-outlined text-lg">close</span>
+          </button>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,6 +34,7 @@
       <%= yield %>
     </div>
     <%= render(partial: "channels/preview/form") %>
+    <%= render(partial: "layouts/global_audio_player") %>
     <footer class="sticky top-[100vh] w-full pt-6 pb-24 md:pb-6 bg-[#3d8bcd] text-white text-center text-sm">
       <div class="max-w-[1440px] mx-auto px-5">
         <%# デスクトップ: 1行 %>

--- a/app/views/my/unreads/channels/items/index.turbo_stream.erb
+++ b/app/views/my/unreads/channels/items/index.turbo_stream.erb
@@ -20,8 +20,8 @@
           </p>
         </div>
         <% if item.audio_enclosure_url %>
-          <div class="audio-player w-full mt-2 -mb-2">
-            <audio class="h-9" style="width: 100%;" src="<%= item.audio_enclosure_url %>" controls controlslist="nodownload"></audio>
+          <div class="w-full mt-2 -mb-2" onclick="event.preventDefault(); event.stopPropagation();">
+            <%= render(partial: "items/audio_queue_button", locals: { item: item, size: :small }) %>
           </div>
         <% end %>
       <% end %>

--- a/app/views/my/unreads/show.html.erb
+++ b/app/views/my/unreads/show.html.erb
@@ -1,6 +1,15 @@
 <% item_count_threshold = 3 %>
 
-<h2 class="mt-[1em] mb-[0.5em] text-2xl font-bold">Unreads</h2>
+<div class="flex items-center justify-between mt-[1em] mb-[0.5em]">
+  <h2 class="text-2xl font-bold">Unreads</h2>
+  <div data-controller="audio-queue-all">
+    <button data-action="audio-queue-all#addAll"
+            class="inline-flex items-center gap-1 text-sm py-2 px-3 bg-[#3d8bcd] text-white rounded hover:bg-[#2d7bbd] transition-colors">
+      <span class="material-symbols-outlined text-base">queue_music</span>
+      <span>すべてキューに追加</span>
+    </button>
+  </div>
+</div>
 
 <p class="flex flex-wrap w-full m-0 mb-2 p-0">Showing unreads from the last <%= @range_days %> days</p>
 <div class="flex m-0 mb-4">
@@ -54,8 +63,8 @@
                 </p>
               </div>
               <% if item.audio_enclosure_url %>
-                <div class="audio-player w-full mt-2 -mb-2">
-                  <audio class="h-9" style="width: 100%;" src="<%= item.audio_enclosure_url %>" controls controlslist="nodownload"></audio>
+                <div class="w-full mt-2 -mb-2" onclick="event.preventDefault(); event.stopPropagation();">
+                  <%= render(partial: "items/audio_queue_button", locals: { item: item, size: :small }) %>
                 </div>
               <% end %>
             <% end %>

--- a/app/views/pawprints/_lines.html.erb
+++ b/app/views/pawprints/_lines.html.erb
@@ -21,8 +21,8 @@
           </p>
         </div>
         <% if item.audio_enclosure_url %>
-          <div class="audio-player w-full mt-2 -mb-2">
-            <audio class="h-9" style="width: 100%;" src="<%= item.audio_enclosure_url %>" controls controlslist="nodownload"></audio>
+          <div class="w-full mt-2">
+            <%= render(partial: "items/audio_queue_button", locals: { item: item }) %>
           </div>
         <% end %>
       </div>


### PR DESCRIPTION
### 概要

現状、ポッドキャストのエピソードには、画面内でひとつひとつに対してaudioタグを添える実装になっています。これは、CDが10枚あるときにCDプレイヤーも10個あるような実装で、HTML的には無駄が多いです。

これを「プレイヤーは全体でひとつ」「ページを移動しても維持される」な実装にして、各エピソードをそこに差し込んで再生できるようなつくりにしたらどうか、試作してみます。

<img width="1200" height="960" alt="fh lvh me_my_unreads" src="https://github.com/user-attachments/assets/e0ab12ae-926e-4c9f-872c-4f480e797ccf" />

<img width="750" height="1334" alt="fh lvh me_my_unreads(iPhone SE)" src="https://github.com/user-attachments/assets/62544887-ba26-4cf8-afdf-e891b1bc4ded" />

### 関連

- https://github.com/kairan-app/feeeed/issues/616
