### PR TITLE
スマートフォンビューで、メニューよりもaudioタグが手前に表示されちゃう問題に対処する

### DIFF
--- a/app/views/items/_cards.html.erb
+++ b/app/views/items/_cards.html.erb
@@ -8,7 +8,7 @@
         </div>
       <% end %>
       <% if item.audio_enclosure_url %>
-        <div class="audio-player audio-player-on-the-image absolute bottom-0 w-[96%] my-1 mx-[2%] z-10">
+        <div class="audio-player audio-player-on-the-image absolute bottom-0 w-[96%] my-1 mx-[2%] z-[3]">
           <audio class="h-[30px]" style="width: 100%;" src="<%= item.audio_enclosure_url %>" controls controlslist="nodownload"></audio>
         </div>
       <% end %>

--- a/app/views/layouts/_menu.html.erb
+++ b/app/views/layouts/_menu.html.erb
@@ -63,7 +63,7 @@
   <% end %>
 </nav>
 
-<nav class="sp-tab hidden max-md:block max-md:fixed max-md:bottom-0 max-md:w-full max-md:h-16 max-md:ml-[-20px] max-md:p-0 max-md:bg-[#3d8bcd] max-md:text-white max-md:z-[1]">
+<nav class="sp-tab hidden max-md:block max-md:fixed max-md:bottom-0 max-md:w-full max-md:h-16 max-md:ml-[-20px] max-md:p-0 max-md:bg-[#3d8bcd] max-md:text-white max-md:z-50">
   <ul class="list-none p-0 max-md:flex max-md:justify-evenly max-md:w-full max-md:h-16 max-md:m-0">
     <li class="max-md:relative max-md:w-[33.33333%] max-md:text-center">
       <%= link_to(root_path, class: "max-md:block max-md:w-full max-md:h-16 max-md:m-0 max-md:pt-9 max-md:text-[10px] max-md:text-white") do %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,7 @@
   </head>
 
   <body class="bg-[#ecf2fa] font-sans break-words">
-    <header class="relative w-[calc(100%-40px)] h-[72px] max-w-[1440px] flex flex-wrap mx-auto z-10 md:w-full">
+    <header class="relative w-[calc(100%-40px)] h-[72px] max-w-[1440px] flex flex-wrap mx-auto z-50 md:w-full">
       <h1 class="flex w-[120px] h-18 items-center ml-0 md:w-[144px] md:ml-[20px]">
         <%= link_to image_tag("logo.svg", class: "w-full h-auto"), root_path, class: "leading-none" %>
       </h1>

--- a/app/views/my/unreads/channels/items/index.turbo_stream.erb
+++ b/app/views/my/unreads/channels/items/index.turbo_stream.erb
@@ -20,7 +20,7 @@
           </p>
         </div>
         <% if item.audio_enclosure_url %>
-          <div class="audio-player w-full mt-2 -mb-2">
+          <div class="audio-player w-full mt-2 -mb-2 z-[3]">
             <audio class="h-9" style="width: 100%;" src="<%= item.audio_enclosure_url %>" controls controlslist="nodownload"></audio>
           </div>
         <% end %>

--- a/app/views/my/unreads/show.html.erb
+++ b/app/views/my/unreads/show.html.erb
@@ -54,7 +54,7 @@
                 </p>
               </div>
               <% if item.audio_enclosure_url %>
-                <div class="audio-player w-full mt-2 -mb-2">
+                <div class="audio-player w-full mt-2 -mb-2 z-[3]">
                   <audio class="h-9" style="width: 100%;" src="<%= item.audio_enclosure_url %>" controls controlslist="nodownload"></audio>
                 </div>
               <% end %>

--- a/app/views/pawprints/_lines.html.erb
+++ b/app/views/pawprints/_lines.html.erb
@@ -21,7 +21,7 @@
           </p>
         </div>
         <% if item.audio_enclosure_url %>
-          <div class="audio-player w-full mt-2 -mb-2">
+          <div class="audio-player w-full mt-2 -mb-2 z-[3]">
             <audio class="h-9" style="width: 100%;" src="<%= item.audio_enclosure_url %>" controls controlslist="nodownload"></audio>
           </div>
         <% end %>


### PR DESCRIPTION
掲題の通り :v:
