### PR TITLE
Unreadsページで、TagsやChannel Groupsの絞り込みメニューが画面を右に伸ばしてしまうのを修正する

### DIFF
--- a/app/views/my/unreads/show.html.erb
+++ b/app/views/my/unreads/show.html.erb
@@ -10,7 +10,7 @@
 
 <div class="flex flex-wrap gap-6 mb-4">
   <% if @subscription_tags.exists? %>
-  <div>
+  <div class="max-w-full overflow-hidden">
     <div class="flex items-center gap-2 mb-2">
       <span class="text-sm font-medium text-gray-700">Tags</span>
       <%= link_to "(Manage)", my_subscriptions_path, class: "text-sm text-gray-500 hover:underline" %>
@@ -25,7 +25,7 @@
   <% end %>
 
   <% if @channel_groups.exists? %>
-  <div>
+  <div class="max-w-full overflow-hidden">
     <div class="flex items-center gap-2 mb-2">
       <span class="text-sm font-medium text-gray-700">Channel Groups</span>
     </div>


### PR DESCRIPTION
- https://github.com/kairan-app/feeeed/pull/644

にて、表示に悪影響が出ていたのでとりいそぎでファーストエイド :pill:
