### PR TITLE
titleがないItemも保存できるように

### DIFF
--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -406,8 +406,6 @@ class Channel < ApplicationRecord
 
     entries.sort_by(&:published).each do |entry|
       begin
-        next if entry.title.blank?
-
         url = entry.url.presence ||
               (entry.respond_to?(:enclosure_url) && entry.enclosure_url.presence) ||
               self.site_url.presence

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -16,6 +16,7 @@ class Item < ApplicationRecord
 
   strip_before_save :title, :image_url
   empty_strings_are_aligned_to_nil :image_url
+  before_validation :fill_blank_title
   after_create_commit { ItemCreationNotifierJob.perform_later(self.id) }
 
   class << self
@@ -85,5 +86,11 @@ class Item < ApplicationRecord
         alt_text: title
       }
     }
+  end
+
+  private
+
+  def fill_blank_title
+    self.title = "〓" if title.blank?
   end
 end


### PR DESCRIPTION
フィードの仕様としてはtitleがないことも許容されているのだけれど、こちらのアプリケーションとしてはtitleがないと表示をつくるときに困るという事情がある。ので、まずは「こちらで用意した文字でフィルする」をやります。

のちのち「データベースでItemのtitleをnullableにして、表示するときに文字を当てる」って方式に切り替えるかも〜とは思っていますが、シュッと対応できる方式から取り入れることにしました。
