### PR TITLE
PR #715 のレビュー指摘を反映する

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -23,8 +23,7 @@ module Types
       when "to_me"
         return [] unless user
         Pawprint
-          .joins(item: :channel)
-          .joins("INNER JOIN ownerships ON ownerships.channel_id = channels.id")
+          .joins(item: { channel: :ownerships })
           .where(ownerships: { user_id: user.id })
       else
         Pawprint.all
@@ -56,7 +55,7 @@ module Types
       range_days = range_days.clamp(1, 365)
 
       base = if channel_group_id.present?
-        channel_group = ChannelGroup.find_by(id: channel_group_id)
+        channel_group = user.own_and_joined_channel_groups.find_by(id: channel_group_id)
         return [] unless channel_group
         channel_group.items
       elsif subscription_tag_id.present?

--- a/cli/cmd/unreads_list.go
+++ b/cli/cmd/unreads_list.go
@@ -109,8 +109,15 @@ func runUnreadsList(cmd *cobra.Command, args []string) error {
 
 	if len(resp.UnreadItems) == unreadsListLimit {
 		oldest := resp.UnreadItems[len(resp.UnreadItems)-1].ID
-		fmt.Fprintf(out, "\n次のページ: rururu unreads list --range-days %d --limit %d --before %s\n",
+		next := fmt.Sprintf("rururu unreads list --range-days %d --limit %d --before %s",
 			unreadsListRangeDays, unreadsListLimit, oldest)
+		if unreadsListChannelGroupID != "" {
+			next += " --channel-group " + unreadsListChannelGroupID
+		}
+		if unreadsListSubscriptionTagID != "" {
+			next += " --tag " + unreadsListSubscriptionTagID
+		}
+		fmt.Fprintf(out, "\n次のページ: %s\n", next)
 	}
 	return nil
 }

--- a/cli/cmd/unreads_list.go
+++ b/cli/cmd/unreads_list.go
@@ -109,13 +109,13 @@ func runUnreadsList(cmd *cobra.Command, args []string) error {
 
 	if len(resp.UnreadItems) == unreadsListLimit {
 		oldest := resp.UnreadItems[len(resp.UnreadItems)-1].ID
-		next := fmt.Sprintf("rururu unreads list --range-days %d --limit %d --before %s",
+		next := fmt.Sprintf("rururu unreads list --range-days %d --limit %d --before %q",
 			unreadsListRangeDays, unreadsListLimit, oldest)
 		if unreadsListChannelGroupID != "" {
-			next += " --channel-group " + unreadsListChannelGroupID
+			next += fmt.Sprintf(" --channel-group %q", unreadsListChannelGroupID)
 		}
 		if unreadsListSubscriptionTagID != "" {
-			next += " --tag " + unreadsListSubscriptionTagID
+			next += fmt.Sprintf(" --tag %q", unreadsListSubscriptionTagID)
 		}
 		fmt.Fprintf(out, "\n次のページ: %s\n", next)
 	}

--- a/test/integration/graphql_test.rb
+++ b/test/integration/graphql_test.rb
@@ -192,4 +192,26 @@ class GraphqlTest < ActionDispatch::IntegrationTest
     body = JSON.parse(response.body)
     assert_equal [], body.dig("data", "unreadItems")
   end
+
+  test "unreadItems with channelGroupId returns items only from groups the user can access" do
+    own_group = create(:channel_group, owner: @user)
+    own_group.channels << @channel
+    item_in_own = create(:item, channel: @channel)
+
+    other_user = create(:user)
+    other_group = create(:channel_group, owner: other_user)
+    other_channel = create(:channel)
+    other_group.channels << other_channel
+    create(:item, channel: other_channel)
+
+    query = "{ unreadItems(channelGroupId: \"#{own_group.id}\") { id } }"
+    post_graphql(query, token: @plain)
+    ids = JSON.parse(response.body).dig("data", "unreadItems").map { |i| i["id"] }
+    assert_equal [ item_in_own.id.to_s ], ids
+
+    query = "{ unreadItems(channelGroupId: \"#{other_group.id}\") { id } }"
+    post_graphql(query, token: @plain)
+    ids = JSON.parse(response.body).dig("data", "unreadItems").map { |i| i["id"] }
+    assert_equal [], ids, "他人所有のChannelGroupから記事が取れてはいけない"
+  end
 end


### PR DESCRIPTION
## Summary
マージ済の #715 に対するレビューコメント([gemini-code-assist](https://github.com/kairan-app/feeeed/pull/715#pullrequestreview-4114244419))への後追い対応。

- **[security/high]** `Query.unreadItems(channelGroupId:)` を `user.own_and_joined_channel_groups.find_by(id:)` でスコープし、認証ユーザーが他人所有のChannelGroupの記事を覗けないように修正
- **[rails/medium]** `Query.pawprints` の `to_me` スコープで使っていた文字列INNER JOINを `joins(item: { channel: :ownerships })` でidiomaticに簡素化
- **[cli/medium]** `rururu unreads list` の「次のページ」案内に `--channel-group` / `--tag` を引き継ぐように修正

## Test plan
- [x] `bin/rails test test/integration/graphql_test.rb` (17 tests, 32 assertions, all green)
- [x] 新規追加: 他人所有ChannelGroupのIDを渡しても空配列が返ることをテストで担保
- [x] `rubocop -c .rubocop.yml app/graphql/types/query_type.rb test/integration/graphql_test.rb` クリーン
- [x] `cd cli && go build / go vet / go test ./...` クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)