### PR TITLE
pawprints listに--since/--until時刻フィルタを追加する

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -11,8 +11,12 @@ module Types
       argument :scope, Types::PawprintScopeType, required: false, default_value: "all"
       argument :first, Integer, required: false, default_value: 50
       argument :before, ID, required: false, description: "このIDより古い足あとを返す(キーセットページング用)。"
+      argument :since, GraphQL::Types::ISO8601DateTime, required: false,
+        description: "この日時以降(含む)に作成された足あとに絞る。"
+      argument :until, GraphQL::Types::ISO8601DateTime, required: false, as: :until_at,
+        description: "この日時以前(含む)に作成された足あとに絞る。"
     end
-    def pawprints(scope:, first:, before: nil)
+    def pawprints(scope:, first:, before: nil, since: nil, until_at: nil)
       first = first.clamp(1, 100)
       user = context[:current_user]
 
@@ -30,6 +34,8 @@ module Types
       end
 
       relation = relation.where("pawprints.id < ?", before) if before.present?
+      relation = relation.where("pawprints.created_at >= ?", since) if since.present?
+      relation = relation.where("pawprints.created_at <= ?", until_at) if until_at.present?
       relation
         .includes(:user, item: :channel)
         .order(id: :desc)

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -11,12 +11,12 @@ module Types
       argument :scope, Types::PawprintScopeType, required: false, default_value: "all"
       argument :first, Integer, required: false, default_value: 50
       argument :before, ID, required: false, description: "このIDより古い足あとを返す(キーセットページング用)。"
-      argument :since, GraphQL::Types::ISO8601DateTime, required: false,
+      argument :since, GraphQL::Types::ISO8601DateTime, required: false, as: :since_at,
         description: "この日時以降(含む)に作成された足あとに絞る。"
       argument :until, GraphQL::Types::ISO8601DateTime, required: false, as: :until_at,
         description: "この日時以前(含む)に作成された足あとに絞る。"
     end
-    def pawprints(scope:, first:, before: nil, since: nil, until_at: nil)
+    def pawprints(scope:, first:, before: nil, since_at: nil, until_at: nil)
       first = first.clamp(1, 100)
       user = context[:current_user]
 
@@ -34,7 +34,7 @@ module Types
       end
 
       relation = relation.where("pawprints.id < ?", before) if before.present?
-      relation = relation.where("pawprints.created_at >= ?", since) if since.present?
+      relation = relation.where("pawprints.created_at >= ?", since_at) if since_at.present?
       relation = relation.where("pawprints.created_at <= ?", until_at) if until_at.present?
       relation
         .includes(:user, item: :channel)

--- a/cli/README.md
+++ b/cli/README.md
@@ -64,6 +64,10 @@ rururu pawprints list --scope all
 rururu pawprints list --limit 100
 rururu pawprints list --before 81
 
+# 期間フィルタ (YYYY-MM-DDはローカルtzの0:00〜23:59:59として解釈)
+rururu pawprints list --since 2026-04-01 --until 2026-04-15
+rururu pawprints list --since 2026-04-15T10:00:00+09:00
+
 # 構造化出力
 rururu pawprints list --json
 ```

--- a/cli/cmd/pawprints_list.go
+++ b/cli/cmd/pawprints_list.go
@@ -13,6 +13,8 @@ var (
 	pawprintsListScope  string
 	pawprintsListLimit  int
 	pawprintsListBefore string
+	pawprintsListSince  string
+	pawprintsListUntil  string
 	pawprintsListJSON   bool
 )
 
@@ -26,6 +28,11 @@ var pawprintsListCmd = &cobra.Command{
   all    全ユーザーの足あと
   to_me  自分が所有するチャンネルへの足あと
 
+期間フィルタ(--since/--until):
+  - YYYY-MM-DD 形式で渡すと、ローカルタイムゾーンの
+    since=その日の0:00:00、until=その日の23:59:59 として扱う。
+  - フルRFC3339(例: 2026-04-15T10:00:00+09:00)でも受け付ける。
+
 ページング:
   最終行に表示される --before <id> を渡すと続きが取れる。`,
 	RunE: runPawprintsList,
@@ -35,6 +42,8 @@ func init() {
 	pawprintsListCmd.Flags().StringVar(&pawprintsListScope, "scope", "my", "表示スコープ (my|all|to_me)")
 	pawprintsListCmd.Flags().IntVar(&pawprintsListLimit, "limit", 50, "取得件数 (1-100)")
 	pawprintsListCmd.Flags().StringVar(&pawprintsListBefore, "before", "", "このIDより古い足あとから表示(ページング用)")
+	pawprintsListCmd.Flags().StringVar(&pawprintsListSince, "since", "", "この日時以降(含む)に作成された足あとに絞る")
+	pawprintsListCmd.Flags().StringVar(&pawprintsListUntil, "until", "", "この日時以前(含む)に作成された足あとに絞る")
 	pawprintsListCmd.Flags().BoolVar(&pawprintsListJSON, "json", false, "JSON形式で出力")
 	pawprintsCmd.AddCommand(pawprintsListCmd)
 }
@@ -62,6 +71,15 @@ func runPawprintsList(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	since, err := parseTimeFlag(pawprintsListSince, startOfDay)
+	if err != nil {
+		return fmt.Errorf("--since: %w", err)
+	}
+	until, err := parseTimeFlag(pawprintsListUntil, endOfDay)
+	if err != nil {
+		return fmt.Errorf("--until: %w", err)
+	}
+
 	client, _, err := authedClient()
 	if err != nil {
 		return err
@@ -73,9 +91,15 @@ func runPawprintsList(cmd *cobra.Command, args []string) error {
 	if pawprintsListBefore != "" {
 		vars["before"] = pawprintsListBefore
 	}
+	if since != "" {
+		vars["since"] = since
+	}
+	if until != "" {
+		vars["until"] = until
+	}
 
-	query := `query($scope: PawprintScope!, $first: Int!, $before: ID) {
-  pawprints(scope: $scope, first: $first, before: $before) {
+	query := `query($scope: PawprintScope!, $first: Int!, $before: ID, $since: ISO8601DateTime, $until: ISO8601DateTime) {
+  pawprints(scope: $scope, first: $first, before: $before, since: $since, until: $until) {
     id
     memo
     createdAt
@@ -115,8 +139,15 @@ func runPawprintsList(cmd *cobra.Command, args []string) error {
 
 	if len(resp.Pawprints) == pawprintsListLimit {
 		oldest := resp.Pawprints[len(resp.Pawprints)-1].ID
-		fmt.Fprintf(out, "\n次のページ: rururu pawprints list --scope %s --limit %d --before %s\n",
+		next := fmt.Sprintf("rururu pawprints list --scope %s --limit %d --before %q",
 			pawprintsListScope, pawprintsListLimit, oldest)
+		if pawprintsListSince != "" {
+			next += fmt.Sprintf(" --since %q", pawprintsListSince)
+		}
+		if pawprintsListUntil != "" {
+			next += fmt.Sprintf(" --until %q", pawprintsListUntil)
+		}
+		fmt.Fprintf(out, "\n次のページ: %s\n", next)
 	}
 	return nil
 }
@@ -140,4 +171,31 @@ func formatTime(iso string) string {
 		return iso
 	}
 	return t.Local().Format("2006-01-02 15:04")
+}
+
+type dateKind int
+
+const (
+	startOfDay dateKind = iota
+	endOfDay
+)
+
+// parseTimeFlag は --since/--until で受け取った文字列をRFC3339へ正規化する。
+// 空文字なら空文字を返す。YYYY-MM-DD形式なら kind に応じて日の開始/終了で補う(ローカルtz)。
+// 既にRFC3339形式ならそのまま返す。
+func parseTimeFlag(s string, kind dateKind) (string, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", nil
+	}
+	if t, err := time.ParseInLocation("2006-01-02", s, time.Local); err == nil {
+		if kind == endOfDay {
+			t = t.Add(24*time.Hour - time.Second)
+		}
+		return t.Format(time.RFC3339), nil
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t.Format(time.RFC3339), nil
+	}
+	return "", fmt.Errorf("invalid time %q (expected YYYY-MM-DD or RFC3339)", s)
 }

--- a/cli/cmd/pawprints_list.go
+++ b/cli/cmd/pawprints_list.go
@@ -190,12 +190,12 @@ func parseTimeFlag(s string, kind dateKind) (string, error) {
 	}
 	if t, err := time.ParseInLocation("2006-01-02", s, time.Local); err == nil {
 		if kind == endOfDay {
-			t = t.Add(24*time.Hour - time.Second)
+			t = t.AddDate(0, 0, 1).Add(-time.Nanosecond)
 		}
-		return t.Format(time.RFC3339), nil
+		return t.Format(time.RFC3339Nano), nil
 	}
-	if t, err := time.Parse(time.RFC3339, s); err == nil {
-		return t.Format(time.RFC3339), nil
+	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+		return t.Format(time.RFC3339Nano), nil
 	}
 	return "", fmt.Errorf("invalid time %q (expected YYYY-MM-DD or RFC3339)", s)
 }

--- a/test/integration/graphql_test.rb
+++ b/test/integration/graphql_test.rb
@@ -131,6 +131,24 @@ class GraphqlTest < ActionDispatch::IntegrationTest
     assert_equal [ pps[0].id.to_s ], ids
   end
 
+  test "pawprints filters by since and until on created_at" do
+    items = Array.new(3) { create(:item, channel: @channel) }
+    pps = items.map { |i| @user.paw(i, memo: nil) }
+    pps[0].update_column(:created_at, Time.zone.parse("2026-04-01 10:00:00"))
+    pps[1].update_column(:created_at, Time.zone.parse("2026-04-05 10:00:00"))
+    pps[2].update_column(:created_at, Time.zone.parse("2026-04-10 10:00:00"))
+
+    query = '{ pawprints(scope: MY, since: "2026-04-03T00:00:00+09:00", until: "2026-04-08T00:00:00+09:00") { id } }'
+    post_graphql(query, token: @plain)
+    ids = JSON.parse(response.body).dig("data", "pawprints").map { |p| p["id"] }
+    assert_equal [ pps[1].id.to_s ], ids
+
+    query = '{ pawprints(scope: MY, since: "2026-04-05T10:00:00+09:00") { id } }'
+    post_graphql(query, token: @plain)
+    ids = JSON.parse(response.body).dig("data", "pawprints").map { |p| p["id"] }
+    assert_equal [ pps[2].id.to_s, pps[1].id.to_s ], ids
+  end
+
   test "pawprints with scope MY returns empty when unauthenticated" do
     @user.paw(create(:item, channel: @channel), memo: "x")
 


### PR DESCRIPTION
## Summary
`rururu pawprints list` に期間絞り込みを追加。

- サーバ: `Query.pawprints` に `since: ISO8601DateTime`, `until: ISO8601DateTime` 追加 (`pawprints.created_at` で両端含む絞り込み)
- CLI: `--since` / `--until` 追加。`YYYY-MM-DD` はローカルtzのsince=0:00、until=23:59:59として解釈、フルRFC3339もそのまま通る
- 「次のページ」案内にも `--since` / `--until` を `%q` でクォートして引き継ぐ

## 使用例
```sh
rururu pawprints list --since 2026-04-01 --until 2026-04-15
rururu pawprints list --since 2026-04-15T10:00:00+09:00
```

## Test plan
- [x] `bin/rails test test/integration/graphql_test.rb` (18 tests, 34 assertions, all green)
- [x] 日付範囲指定/since-only両方の期待値テスト追加
- [x] 無効フォーマット `--since "not-a-date"` でエラーメッセージ表示を確認
- [x] `cd cli && go build / vet / test ./...` クリーン、rubocopクリーン
- [x] ローカルサーバに対してYYYY-MM-DD / RFC3339両パターンでフィルタ動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)