### PR TITLE
feat(items): 未来日時のItemを一覧に表示しない

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   def index
     page = (params[:page].presence || 1).to_i
-    @items = Item.where("published_at <= ?", 1.month.from_now).preload(:pawprints).eager_load(:channel).order(published_at: :desc, title: :desc).page(page).per(48)
+    @items = Item.published_before(1.month.from_now).preload(:pawprints).eager_load(:channel).order(published_at: :desc, title: :desc).page(page).per(48)
 
     @title = page == 1 ? "Items" : "Items (Page #{page})"
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   def index
     page = (params[:page].presence || 1).to_i
-    @items = Item.published_before(1.month.from_now).preload(:pawprints).eager_load(:channel).order(published_at: :desc, title: :desc).page(page).per(48)
+    @items = Item.published_before(Time.current).preload(:pawprints).eager_load(:channel).order(published_at: :desc, title: :desc).page(page).per(48)
 
     @title = page == 1 ? "Items" : "Items (Page #{page})"
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   def index
     page = (params[:page].presence || 1).to_i
-    @items = Item.preload(:pawprints).eager_load(:channel).order(published_at: :desc, title: :desc).page(page).per(48)
+    @items = Item.where("published_at <= ?", 1.month.from_now).preload(:pawprints).eager_load(:channel).order(published_at: :desc, title: :desc).page(page).per(48)
 
     @title = page == 1 ? "Items" : "Items (Page #{page})"
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -14,6 +14,8 @@ class Item < ApplicationRecord
   validates :published_at, presence: true
   validates_url_http_format_of :url, :image_url
 
+  scope :published_before, ->(time) { where("published_at <= ?", time) }
+
   strip_before_save :title, :image_url
   empty_strings_are_aligned_to_nil :image_url
   before_validation :fill_blank_title

--- a/test/integration/items_test.rb
+++ b/test/integration/items_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class ItemsTest < ActionDispatch::IntegrationTest
+  test "shows items published within one month from now" do
+    item = create(:item, title: "Near Future Item", published_at: 3.weeks.from_now)
+
+    get items_path
+
+    assert_response :success
+    assert_match(/Near Future Item/, response.body)
+  end
+
+  test "does not show items published more than one month from now" do
+    item = create(:item, title: "Far Future Item", published_at: 2.months.from_now)
+
+    get items_path
+
+    assert_response :success
+    assert_no_match(/Far Future Item/, response.body)
+  end
+end

--- a/test/integration/items_test.rb
+++ b/test/integration/items_test.rb
@@ -1,21 +1,21 @@
 require "test_helper"
 
 class ItemsTest < ActionDispatch::IntegrationTest
-  test "shows items published within one month from now" do
-    item = create(:item, title: "Near Future Item", published_at: 3.weeks.from_now)
+  test "shows items published in the past" do
+    item = create(:item, title: "Past Item", published_at: 1.hour.ago)
 
     get items_path
 
     assert_response :success
-    assert_match(/Near Future Item/, response.body)
+    assert_match(/Past Item/, response.body)
   end
 
-  test "does not show items published more than one month from now" do
-    item = create(:item, title: "Far Future Item", published_at: 2.months.from_now)
+  test "does not show items published in the future" do
+    item = create(:item, title: "Future Item", published_at: 1.day.from_now)
 
     get items_path
 
     assert_response :success
-    assert_no_match(/Far Future Item/, response.body)
+    assert_no_match(/Future Item/, response.body)
   end
 end


### PR DESCRIPTION
## Summary
- `/items` に未来の `published_at` を持つ Item が先頭に並んでしまう問題に対処
- `Item.published_before(Time.current)` で、現在時刻より未来の Item は表示しない (割り切り)
- 「新しい順」の表示順 (`order(published_at: :desc, title: :desc)`) はそのまま維持
- 絞り込みは `Item.published_before(time)` scope に切り出し済み (レビュー反映)
- `channels#show` 等の他の表示箇所は今回は対象外 (意図的にそのまま)

## Test plan
- [x] `test/integration/items_test.rb` を追加 (TDD)
  - 過去の Item は表示される
  - 未来の Item は表示されない
- [x] `rails test test/integration/items_test.rb` が green
- [x] `rubocop` オフェンスなし