### PR TITLE
fix(items): Item削除時にitem_skipsをdependent: destroyで掃除する

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,6 +6,7 @@ class Item < ApplicationRecord
   belongs_to :channel
   has_many :pawprints, dependent: :destroy
   has_many :pawed_users, through: :pawprints, source: :user
+  has_many :item_skips, dependent: :destroy
 
   validates :channel_id, presence: true
   validates :guid, presence: true, length: { maximum: 2083 }, uniqueness: { scope: :channel_id }

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+
+class ItemTest < ActiveSupport::TestCase
+  describe "dependent destroy" do
+    test "Itemを削除すると紐づくitem_skipsも削除される" do
+      item = create(:item)
+      user = create(:user)
+      ItemSkip.create!(user: user, item: item)
+
+      assert_difference("ItemSkip.count", -1) do
+        item.destroy!
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- `Item` に `has_many :item_skips, dependent: :destroy` を追加
- skip履歴のあるItemを含むChannel(やItem単体)の削除が、`item_skips`の外部キー制約違反(`fk_rails_9e6cfdac5c`)で落ちていたのを修正
- `User` 側には既に `dependent: :destroy` があり、`Item` 側だけ非対称だったのを揃えた
- 回帰防止のため `test/models/item_test.rb` を新規追加

## Test plan
- [x] `rails test test/models/item_test.rb` (Item削除でitem_skipsが道連れに消える)
- [x] `rails test test/models/` 全体 (79 runs, 0 failures)
- [x] `rubocop` no offenses