### PR TITLE
Bump brakeman from 8.0.4 to 8.0.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,7 +107,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.24.6)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     builder (3.3.0)
     capybara (3.40.0)
@@ -572,7 +572,7 @@ CHECKSUMS
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
   bootsnap (1.24.6) sha256=c60bab88c70332290f0a2636a288f675299eb4f804a02a3c085b42eca9da164a
-  brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
+  brakeman (8.0.5) sha256=03735f9690d3fd4b32d66aacbf0a6d15a84266bdd06b32c05c8ecc8f6021d2be
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef


### PR DESCRIPTION
## Summary
- `brakeman` を 8.0.4 → 8.0.5 に更新
- `bin/brakeman` が `--ensure-latest` を付けて実行するため、最新版でないと CI の `scan_ruby` が exit code 5 で失敗する。8.0.5 が出たことで現状の main でも落ちる状態になっていたので追従する
- ローカルで `bin/brakeman --no-pager` 実行済み: `Errors: 0 / Security Warnings: 0 / No warnings found`

## Test plan
- [x] `bin/brakeman --no-pager` がパス (v8.0.5, 警告なし)
- [x] CI の `scan_ruby` が green になること