### PR TITLE
fix(deps): graphql 2.6.4がyankedされたため2.6.3に戻す

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,7 +186,7 @@ GEM
       os (>= 0.9, < 2.0)
       pstore (~> 0.1)
       signet (>= 0.16, < 2.a)
-    graphql (2.6.4)
+    graphql (2.6.3)
       base64
       fiber-storage
       logger
@@ -612,7 +612,7 @@ CHECKSUMS
   google-cloud-env (2.3.1) sha256=0faac01eb27be78c2591d64433663b1a114f8f7af55a4f819755426cac9178e7
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
   googleauth (1.17.1) sha256=0f7e6fc70e204cee1b2d71f1e1de2d3b349d432404197fe68ebf7fa23d0821b9
-  graphql (2.6.4) sha256=b5ea1ea6d584fb36d3ac81d10d4842ec6bb0cbb71bbd099e69541cb524c0d1c4
+  graphql (2.6.3) sha256=31fe845b509fda27db38d09380f27ffc0de1c7ea2f9f3b12fa42bdde8317239b
   hiredis (0.6.3) sha256=7f052e320f7d24b5c2a9fdf67c6ff6facdf6e256394a703511bce34ecf445212
   http-cookie (1.1.6) sha256=ba4b82be64de61dc281243dac70e3c382c45142f20268ed9276a3670c93feaa9
   i18n (1.15.1) sha256=505ec5de1f4e6c8a2cb028ef9700ca495f117911643455721dee5abdca797255


### PR DESCRIPTION
## Summary
- graphql 2.6.4がRubyGemsからyanked(削除)されており、`bundle install`が失敗する状態を修正
- Gemfile.lockを利用可能な最新版2.6.3にロックし直した

## Test plan
- [x] CI green
- [x] `bundle install`が正常に完了すること