### PR TITLE
feat(cli): pawprints listのJSON出力にimageUrlを追加

### DIFF
--- a/cli/cmd/pawprints_list.go
+++ b/cli/cmd/pawprints_list.go
@@ -57,10 +57,12 @@ type pawprintListItem struct {
 		Name string `json:"name"`
 	} `json:"user"`
 	Item struct {
-		Title   string `json:"title"`
-		URL     string `json:"url"`
-		Channel struct {
-			Title string `json:"title"`
+		Title    string `json:"title"`
+		URL      string `json:"url"`
+		ImageURL string `json:"imageUrl"`
+		Channel  struct {
+			Title    string `json:"title"`
+			ImageURL string `json:"imageUrl"`
 		} `json:"channel"`
 	} `json:"item"`
 }
@@ -104,7 +106,7 @@ func runPawprintsList(cmd *cobra.Command, args []string) error {
     memo
     createdAt
     user { id name }
-    item { title url channel { title } }
+    item { title url imageUrl channel { title imageUrl } }
   }
 }`
 


### PR DESCRIPTION
## Summary
- `pawprints list --json` の出力に `item.imageUrl` と `item.channel.imageUrl` を追加
- GraphQLクエリとGo structの両方に `imageUrl` フィールドを追加
- jbtでPawprintsをサムネイル付き表示するための準備

## Test plan
- [x] `rururu --profile prod pawprints list --limit 1 --json` で `imageUrl` が含まれることを確認
- [x] imageUrlが未設定のitemで空文字が返ることを確認
- [x] テキスト出力(--jsonなし)が従来どおり動くことを確認