### PR TITLE
Channelのdescriptionの最大長を1024文字から1400文字に拡張する

### DIFF
--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -15,7 +15,7 @@ class Channel < ApplicationRecord
   has_many :fixed_schedules, class_name: "ChannelFixedSchedule", dependent: :destroy
 
   validates :title, presence: true, length: { maximum: 256 }
-  validates :description, length: { maximum: 1024 }
+  validates :description, length: { maximum: 1400 }
   validates :feed_url, presence: true, uniqueness: true
   validates_url_http_format_of :feed_url, :site_url, :image_url
 

--- a/db/migrate/20260731130900_change_description_limit_for_channels.rb
+++ b/db/migrate/20260731130900_change_description_limit_for_channels.rb
@@ -1,0 +1,12 @@
+class ChangeDescriptionLimitForChannels < ActiveRecord::Migration[8.1]
+  NEW_DESCRIPTION_LIMIT = 1400
+  OLD_DESCRIPTION_LIMIT = 1024
+
+  def up
+    change_column :channels, :description, :string, limit: NEW_DESCRIPTION_LIMIT
+  end
+
+  def down
+    change_column :channels, :description, :string, limit: OLD_DESCRIPTION_LIMIT
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_14_045406) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_31_130900) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -152,7 +152,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_14_045406) do
     t.json "applied_filters", default: []
     t.integer "check_interval_hours", default: 1
     t.datetime "created_at", null: false
-    t.string "description", limit: 1024
+    t.string "description", limit: 1400
     t.string "feed_url", limit: 4096, null: false
     t.json "filter_details", default: {}
     t.string "image_url", limit: 4096

--- a/test/models/channel_test.rb
+++ b/test/models/channel_test.rb
@@ -7,6 +7,16 @@ class ChannelTest < ActiveSupport::TestCase
       channel = Channel.new
       assert_not(channel.save, "保存に失敗する")
     end
+
+    test "descriptionは1400文字まで保存できる" do
+      channel = Channel.new(title: "foo", feed_url: "https://example.com/feed.xml", description: "a" * 1400)
+      assert(channel.save, "保存に成功する")
+    end
+
+    test "descriptionが1400文字を超えると保存に失敗する" do
+      channel = Channel.new(title: "foo", feed_url: "https://example.com/feed.xml", description: "a" * 1401)
+      assert_not(channel.save, "保存に失敗する")
+    end
   end
 
   describe "Add" do


### PR DESCRIPTION
## Summary
- Podcastフィード (omny.fm) のChannel保存が `Description is too long (maximum is 1024 characters)` で失敗していたため、上限を1400文字に拡張
- `channels.description` のカラム定義を `varchar(1024)` → `varchar(1400)` に変更するmigrationを追加 (up/down両方定義)
- `Channel` の `validates :description, length: { maximum: 1400 }` に更新し、境界値のテストを追加

## 背景

Podcastフィードの `<description>` には装飾リンク入りのHTMLがそのまま入るため1024文字を超えることがある。`Channel.save_from` は bang なしの `update` を使っているのでvalidation失敗が例外にならず、`ChannelsController#create` が理由の分からない `Can't save channel from '...'` を出すだけになっていた。

## Test plan
- [x] `bin/rails test` (168 runs, 485 assertions, 0 failures, 0 errors)
- [x] `bundle exec rubocop -c .rubocop.yml` (no offenses)
- [x] 追加テストがmigration適用前にRed、適用後にGreenになることを確認
- [x] 実際に失敗していたフィードをローカルでパースし、`Channel#valid?` が true になることを確認
- [ ] 本番デプロイ時にmigrationの実行が必要